### PR TITLE
Inital commit for dpt example

### DIFF
--- a/huggingface/depth-estimation/dpt/compile.py
+++ b/huggingface/depth-estimation/dpt/compile.py
@@ -1,0 +1,36 @@
+import argparse
+import os
+
+from optimum.rbln import RBLNDPTForDepthEstimation
+
+
+def parsing_argument():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--image_size",
+        type=int,
+        default=384,
+        help="(int) type, Size of the image.",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parsing_argument()
+    model_id = "Intel/dpt-large"
+
+    # Compile and export
+    model = RBLNDPTForDepthEstimation.from_pretrained(
+        model_id=model_id,
+        export=True,  # export a PyTorch model to RBLN model with optimum
+        rbln_batch_size=1,
+        rbln_image_size=args.image_size,  # target image size of the model
+    )
+
+    # Save compiled results to disk
+    model.save_pretrained(os.path.basename(model_id))
+
+
+if __name__ == "__main__":
+    main()

--- a/huggingface/depth-estimation/dpt/inference.py
+++ b/huggingface/depth-estimation/dpt/inference.py
@@ -1,0 +1,46 @@
+import os
+
+import requests
+import torch
+from optimum.rbln import RBLNDPTForDepthEstimation
+from PIL import Image
+from transformers import AutoImageProcessor
+
+
+def main():
+    model_id = "Intel/dpt-large"
+
+    # Load compiled model
+    model = RBLNDPTForDepthEstimation.from_pretrained(
+        model_id=os.path.basename(model_id),
+        export=False,  # export a PyTorch model to RBLN model with optimum
+    )
+
+    # Load the image
+    url = "http://images.cocodataset.org/val2017/000000039769.jpg"
+    image = Image.open(requests.get(url, stream=True).raw)
+
+    # Prepare image for the model
+    image_processor = AutoImageProcessor.from_pretrained(model_id)
+    inputs = image_processor(images=image, return_tensors="pt")
+
+    # Inference
+    predicted_depth = model(**inputs).predicted_depth
+
+    # Interpolate to original size
+    prediction = torch.nn.functional.interpolate(
+        predicted_depth.unsqueeze(1),
+        size=image.size[::-1],
+        mode="bicubic",
+        align_corners=False,
+    )
+
+    # visualize the prediction
+    output = prediction.squeeze()
+    formatted = (output * 255 / torch.max(output)).numpy().astype("uint8")
+    depth_image = Image.fromarray(formatted)
+    depth_image.save("depth_image.png")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is an example code for [DPT Model](https://huggingface.co/docs/transformers/model_doc/dpt#transformers.DPTForDepthEstimation) with a depth estimation head on top.

Here's how to change the original code to work with the RBLN NPU.

```diff
-from transformers import AutoImageProcessor, DPTForDepthEstimation
+from transformers import AutoImageProcessor
+from optimum.rbln import RBLNDPTForDepthEstimation
import torch
import numpy as np
from PIL import Image
import requests

url = "http://images.cocodataset.org/val2017/000000039769.jpg"
image = Image.open(requests.get(url, stream=True).raw)

image_processor = AutoImageProcessor.from_pretrained("Intel/dpt-large")
-model = DPTForDepthEstimation.from_pretrained("Intel/dpt-large")
+model = RBLNDPTForDepthEstimation.from_pretrained("Intel/dpt-large", export=True)

# prepare image for the model
inputs = image_processor(images=image, return_tensors="pt")

with torch.no_grad():
    outputs = model(**inputs)
    predicted_depth = outputs.predicted_depth

# interpolate to original size
prediction = torch.nn.functional.interpolate(
    predicted_depth.unsqueeze(1),
    size=image.size[::-1],
    mode="bicubic",
    align_corners=False,
)

# visualize the prediction
output = prediction.squeeze().cpu().numpy()
formatted = (output * 255 / np.max(output)).astype("uint8")
depth = Image.fromarray(formatted)
```