### PR TITLE
Add model: Distilbert

### DIFF
--- a/huggingface/question-answering/distilbert/compile.py
+++ b/huggingface/question-answering/distilbert/compile.py
@@ -10,6 +10,9 @@ def parsing_argument():
         "--model_name",
         type=str,
         default="distilbert-base-uncased-distilled-squad",
+        choices=[
+            "distilbert-base-uncased-distilled-squad",
+        ],
         help="(str) type of distilbert",
     )
     return parser.parse_args()

--- a/huggingface/question-answering/distilbert/compile.py
+++ b/huggingface/question-answering/distilbert/compile.py
@@ -1,0 +1,33 @@
+import os
+import argparse
+from optimum.rbln import RBLNDistilBertForQuestionAnswering
+
+
+def parsing_argument():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--model_name",
+        type=str,
+        default="distilbert-base-uncased-distilled-squad",
+        help="(str) type of distilbert",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parsing_argument()
+    model_id = f"distilbert/{args.model_name}"
+
+    # Compile and export
+    model = RBLNDistilBertForQuestionAnswering.from_pretrained(
+        model_id=model_id,
+        export=True,  # export a PyTorch model to RBLN model with optimum
+        rbln_batch_size=1,
+    )
+    # Save compiled results to disk
+    model.save_pretrained(os.path.basename(model_id))
+
+
+if __name__ == "__main__":
+    main()

--- a/huggingface/question-answering/distilbert/inference.py
+++ b/huggingface/question-answering/distilbert/inference.py
@@ -1,0 +1,62 @@
+import os
+import argparse
+
+from transformers import pipeline
+from optimum.rbln import RBLNDistilBertForQuestionAnswering
+
+
+def parsing_argument():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--model_name",
+        type=str,
+        default="distilbert-base-uncased-distilled-squad",
+        help="(str) type of distilbert",
+    )
+    parser.add_argument(
+        "--question",
+        type=str,
+        default="Who was Jim Henson?",
+        help="(str) type, question text",
+    )
+    parser.add_argument(
+        "--context",
+        type=str,
+        default="Jim Henson was a nice puppet",
+        help="(str) type, context text",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parsing_argument()
+    model_id = f"distilbert/{args.model_name}"
+
+    # Load compiled model
+    model = RBLNDistilBertForQuestionAnswering.from_pretrained(
+        model_id=os.path.basename(model_id),
+        export=False,
+    )
+
+    # Generate Answer
+    pipe = pipeline(
+        "question-answering",
+        model=model,
+        tokenizer=model_id,
+        padding="max_length",
+        max_seq_len=512,
+    )
+    answer = pipe(question=args.question, context=args.context)
+
+    # Result
+    print("--- question ---")
+    print(args.question)
+    print("--- context ---")
+    print(args.context)
+    print("--- Result ---")
+    print(answer)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR introduces a Python example for running the DistilBERT language model on the ATOM NPU using the RBLN SDK. 

The addition demonstrates how to efficiently deploy and perform inference with this popular lightweight BERT variant, showcasing our platform's capabilities for compact yet powerful natural language processing tasks.