### PR TITLE
fix: no pretracing for yolo

### DIFF
--- a/pytorch/vision/detection/yolov3/compile.py
+++ b/pytorch/vision/detection/yolov3/compile.py
@@ -25,9 +25,6 @@ def main():
     model = attempt_load(model_name + ".pt")
     model.eval()
 
-    # for pre-tracing for torch.jit.trace
-    model(torch.zeros(1, 3, 640, 640))
-
     # Compile torch model for ATOM
     input_info = [
         ("input_np", [1, 3, 640, 640], torch.float32),

--- a/pytorch/vision/detection/yolov4/compile.py
+++ b/pytorch/vision/detection/yolov4/compile.py
@@ -34,9 +34,6 @@ def main():
     load_darknet_weights(model, weight)
     model.eval()
 
-    # for pre-tracing for torch.jit.trace
-    model(torch.zeros(1, 3, 640, 640))
-
     # Compile torch model for ATOM
     input_info = [
         ("input_np", [1, 3, 640, 640], torch.float32),

--- a/pytorch/vision/detection/yolov5/compile.py
+++ b/pytorch/vision/detection/yolov5/compile.py
@@ -21,9 +21,6 @@ def main():
     model = torch.hub.load("ultralytics/yolov5", model_name)
     model.eval()
 
-    # for pre-tracing for torch.jit.trace
-    model(torch.zeros(1, 3, 640, 640))
-
     # Compile torch model for ATOM
     input_info = [
         ("input_np", [1, 3, 640, 640], torch.float32),

--- a/pytorch/vision/detection/yolov7/compile.py
+++ b/pytorch/vision/detection/yolov7/compile.py
@@ -35,9 +35,6 @@ def main():
     model = attempt_load(model_name + ".pt", map_location=torch.device("cpu"))
     model.eval()
 
-    # for pre-tracing for torch.jit.trace
-    model(torch.zeros(1, 3, 640, 640))
-
     # Compile torch model for ATOM
     input_info = [
         ("input_np", [1, 3, 640, 640], torch.float32),

--- a/pytorch/vision/detection/yolov8/compile.py
+++ b/pytorch/vision/detection/yolov8/compile.py
@@ -23,9 +23,6 @@ def main():
     model = YOLO(model_name + ".pt").model
     model.eval()
 
-    # for pre-tracing for torch.jit.trace
-    model(torch.zeros(1, 3, 640, 640))
-
     # Compile torch model for ATOM
     input_info = [
         ("input_np", [1, 3, 640, 640], torch.float32),


### PR DESCRIPTION
This PR streamlines the YOLO object detection example in our model zoo by eliminating an unnecessary pre-tracing process. 

The change maintains full functionality while providing a cleaner, more straightforward example for users.