### PR TITLE
Add model/yolos dynamo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 *.jpg
 *.png
 *.bin
+*.pt
 __pycache__/

--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "pytorch/vision/detection/yolov4/yolov4"]
 	path = pytorch/vision/detection/yolov4/yolov4
 	url = https://github.com/WongKinYiu/PyTorch_YOLOv4.git
+[submodule "pytorch/vision/pose_estimation/motionbert/MotionBERT"]
+	path = pytorch/vision/pose_estimation/motionbert/MotionBERT
+	url = https://github.com/Walter0807/MotionBERT.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,19 @@
 [submodule "pytorch/vision/pose_estimation/motionbert/MotionBERT"]
 	path = pytorch/vision/pose_estimation/motionbert/MotionBERT
 	url = https://github.com/Walter0807/MotionBERT.git
+[submodule "pytorch_dynamo/vision/detection/yolox/YOLOX"]
+	path = pytorch_dynamo/vision/detection/yolox/YOLOX
+	url = https://github.com/Megvii-BaseDetection/YOLOX
+[submodule "pytorch_dynamo/vision/detection/yolov5/yolov5"]
+	path = pytorch_dynamo/vision/detection/yolov5/yolov5
+	url = https://github.com/ultralytics/yolov5.git
+[submodule "pytorch_dynamo/vision/detection/yolov6/YOLOv6"]
+	path = pytorch_dynamo/vision/detection/yolov6/YOLOv6
+	url = https://github.com/meituan/YOLOv6.git
+[submodule "pytorch_dynamo/vision/detection/yolov3/yolov3"]
+	path = pytorch_dynamo/vision/detection/yolov3/yolov3
+	url = https://github.com/ultralytics/yolov3.git
+[submodule "pytorch_dynamo/vision/detection/yolov4/yolov4"]
+	path = pytorch_dynamo/vision/detection/yolov4/yolov4
+	url = https://github.com/WongKinYiu/PyTorch_YOLOv4.git
+  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## August, 16th 2024 (v0.5.0)
+- Compatible version:
+    - `rebel-compiler`: v0.5.8
+    - `optimum-rbln`: v0.1.8
+- We are excited to announce support for pytorch2.0 dynamic feature, i.e. torch.compile(). Sample code can be found in `rbln-model-zoo/pytorch_dynamo`.
+- Added a new model:
+    - `Natural Language Processing`:
+        - Mi:dm-7b
+        - BGE-M3
+        - BGE-Reranker-v2-m3
+        - SecureBERT
+        - RoBERTa
+
 ## July, 25th 2024 (v0.4.1)
 - Compatible version:
     - `rebel-compiler`: v0.5.7

--- a/pytorch/requirements.txt
+++ b/pytorch/requirements.txt
@@ -25,4 +25,4 @@ FlagEmbedding==1.2.10 # bge-m3
 easydict==1.13 # motionbert
 ipdb==0.13.13 # motionbert
 smplx==0.1.28 # motionbert
-imageio_ffmpeg==0.5.1 # motionbert
+imageio_ffmpeg==0.4.9 # motionbert

--- a/pytorch/requirements.txt
+++ b/pytorch/requirements.txt
@@ -22,3 +22,7 @@ onnxruntime==1.14.1 # 3ddfa
 loguru==0.6.0 # yolox
 tabulate==0.9.0 # yolox
 FlagEmbedding==1.2.10 # bge-m3
+easydict==1.13 # motionbert
+ipdb==0.13.13 # motionbert
+smplx==0.1.28 # motionbert
+imageio_ffmpeg==0.5.1 # motionbert

--- a/pytorch/vision/pose_estimation/motionbert/compile.py
+++ b/pytorch/vision/pose_estimation/motionbert/compile.py
@@ -1,0 +1,67 @@
+import os
+import sys
+import argparse
+import torch
+import rebel
+
+import urllib.request
+
+sys.path.append(os.path.join(sys.path[0], "MotionBERT"))
+from lib.utils.tools import get_config
+from lib.utils.learning import load_backbone
+
+CONFIG = {
+    "base": "/MotionBERT/configs/pose3d/MB_ft_h36m.yaml",
+    "lite": "/MotionBERT/configs/pose3d/MB_ft_h36m_global_lite.yaml",
+}
+
+CHECKPOINT_FOLDER = {
+    "base": "FT_MB_release_MB_ft_h36m",
+    "lite": "FT_MB_lite_MB_ft_h36m_global_lite",
+}
+
+
+def parsing_argument():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model_name",
+        type=str,
+        default="base",
+        choices=["base", "lite"],
+        help="(str) type, motionbert 3dpose model_name.",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parsing_argument()
+    model_name = args.model_name
+
+    # prepare model
+    cfg = get_config(sys.path[0] + CONFIG[model_name])
+
+    MAX_CLIP_LEN = 243
+
+    model = load_backbone(cfg)
+
+    save_path = "./checkpoint/pose3d/" + CHECKPOINT_FOLDER[model_name] + "/"
+    os.makedirs(save_path, exist_ok=True)
+    hf_url = f"https://huggingface.co/walterzhu/MotionBERT/resolve/main/checkpoint/pose3d/{CHECKPOINT_FOLDER[model_name]}/best_epoch.bin"
+    urllib.request.urlretrieve(hf_url, save_path + "best_epoch.bin")
+    state_dict = torch.load(save_path + "best_epoch.bin")["model_pos"]
+    state_dict = {k[7:]: v for k, v in state_dict.items()}
+    model.load_state_dict(state_dict, strict=True)
+    model.eval()
+
+    # Compile torch model for ATOM
+    input_info = [
+        ("input_np", [1, MAX_CLIP_LEN, 17, 3], torch.float32),
+    ]
+    compiled_model = rebel.compile_from_torch(model, input_info)
+
+    # Save compiled results to disk
+    compiled_model.save(f"motionbert_pose3d_{model_name}.rbln")
+
+
+if __name__ == "__main__":
+    main()

--- a/pytorch/vision/pose_estimation/motionbert/inference.py
+++ b/pytorch/vision/pose_estimation/motionbert/inference.py
@@ -1,0 +1,109 @@
+import os
+import sys
+import imageio
+import argparse
+from torch.utils.data import DataLoader
+import torch
+import rebel
+
+import numpy as np
+import urllib.request
+
+sys.path.append(os.path.join(sys.path[0], "MotionBERT"))
+from lib.utils.tools import get_config
+from lib.utils.utils_data import flip_data
+from lib.data.dataset_wild import WildDetDataset
+from lib.utils.vismo import render_and_save
+
+
+CONFIG = {
+    "base": "/MotionBERT/configs/pose3d/MB_ft_h36m.yaml",
+    "lite": "/MotionBERT/configs/pose3d/MB_ft_h36m_global_lite.yaml",
+}
+
+
+def parsing_argument():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model_name",
+        type=str,
+        default="base",
+        choices=["base", "lite"],
+        help="(str) type, motionbert 3dpose model_name.",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parsing_argument()
+    model_name = args.model_name
+
+    # prepare model
+    cfg = get_config(sys.path[0] + CONFIG[model_name])
+
+    MAX_CLIP_LEN = 243
+
+    # ref: https://github.com/KevinLTT/video2bvh/blob/master/miscs/cxk.mp4
+    vid_url = "https://rbln-public.s3.ap-northeast-2.amazonaws.com/dataset/motionbert/sample.mp4"
+    urllib.request.urlretrieve(vid_url, "./sample.mp4")
+    json_url = "https://rbln-public.s3.ap-northeast-2.amazonaws.com/dataset/motionbert/alphapose-results.json"
+    urllib.request.urlretrieve(json_url, "./alphapose-results.json")
+
+    testloader_params = {
+        "batch_size": 1,
+        "shuffle": False,
+        "num_workers": 8,
+        "pin_memory": True,
+        "prefetch_factor": 4,
+        "persistent_workers": True,
+        "drop_last": False,
+    }
+    vid = imageio.get_reader("./sample.mp4", "ffmpeg")
+    fps_in = vid.get_meta_data()["fps"]
+    wild_dataset = WildDetDataset(
+        "alphapose-results.json", clip_len=MAX_CLIP_LEN, scale_range=[1, 1], focus=None
+    )
+    test_loader = DataLoader(wild_dataset, **testloader_params)
+
+    # Load compiled model to RBLN runtime module
+    module = rebel.Runtime(f"motionbert_pose3d_{model_name}.rbln", tensor_type="pt")
+
+    # inference
+    results_all = []
+    for batch_input in test_loader:
+        T = batch_input.shape[1]
+        if cfg.no_conf:
+            batch_input = batch_input[:, :, :, :2]
+        if T != MAX_CLIP_LEN:
+            repeat_end_of_frames = [batch_input] + [
+                batch_input[:, -1:, :, :] for _ in range(MAX_CLIP_LEN - T)
+            ]
+            batch_input = torch.concat(repeat_end_of_frames, dim=1)
+        if cfg.flip:
+            batch_input_flip = flip_data(batch_input)
+            predicted_3d_pos_1 = module.run(batch_input)
+            predicted_3d_pos_flip = module.run(batch_input_flip)
+            predicted_3d_pos_2 = flip_data(predicted_3d_pos_flip)  # Flip back
+            predicted_3d_pos = (predicted_3d_pos_1 + predicted_3d_pos_2) / 2.0
+        else:
+            predicted_3d_pos = module.run(batch_input)
+        if cfg.rootrel:
+            predicted_3d_pos[:, :, 0, :] = 0  # [N,T,17,3]
+        else:
+            predicted_3d_pos[:, 0, 0, 2] = 0
+            pass
+        if cfg.gt_2d:
+            predicted_3d_pos[..., :2] = batch_input[..., :2]
+        if T != MAX_CLIP_LEN:
+            predicted_3d_pos = predicted_3d_pos[:, :T, :, :]
+        results_all.append(predicted_3d_pos.cpu().numpy())
+
+    results_all = np.hstack(results_all)
+    results_all = np.concatenate(results_all)
+
+    # rendering video using result
+    render_and_save(results_all, f"./3dpose_{model_name}.mp4", keep_imgs=False, fps=fps_in)
+
+
+if __name__ == "__main__":
+    main()

--- a/pytorch_dynamo/requirements.txt
+++ b/pytorch_dynamo/requirements.txt
@@ -17,3 +17,5 @@ torchaudio==2.2.1 # convtasnet
 torchvision==0.17.1
 transformers==4.40.2
 ultralytics==8.0.145
+loguru==0.6.0 # yolox
+tabulate==0.9.0 # yolox

--- a/pytorch_dynamo/vision/detection/yolov3/main.py
+++ b/pytorch_dynamo/vision/detection/yolov3/main.py
@@ -1,0 +1,102 @@
+import argparse
+import contextlib
+import os
+import sys
+import urllib.request
+import warnings
+
+import cv2
+import numpy as np
+import rebel  # noqa: F401  # needed to use torch dynamo's "rbln" backend.
+import torch
+import yaml
+
+sys.path.append(os.path.join(sys.path[0], "yolov3"))
+from yolov3.models.experimental import attempt_load
+from yolov3.utils.augmentations import letterbox
+from yolov3.utils.general import non_max_suppression as nms
+from yolov3.utils.general import scale_boxes
+from yolov3.utils.plots import Annotator, colors
+
+
+def preprocess(image):
+    preprocess_input = letterbox(image, (640, 640), 32, auto=False)[0]
+    preprocess_input = preprocess_input.transpose((2, 0, 1))[::-1]
+    preprocess_input = np.ascontiguousarray(preprocess_input, dtype=np.float32)
+    preprocess_input = preprocess_input[None]
+    preprocess_input /= 255
+
+    return preprocess_input
+
+
+def postprocess(outputs, input_image, origin_image):
+    pred = nms(outputs[0], 0.25, 0.45, None, False, max_det=1000)[0]
+    annotator = Annotator(origin_image, line_width=3)
+    pred[:, :4] = scale_boxes(input_image.shape[2:], pred[:, :4], origin_image.shape).round()
+    yaml_path = os.path.abspath(os.path.dirname(__file__)) + "/yolov3/data/coco128.yaml"
+    with open(yaml_path) as f:
+        data = yaml.safe_load(f)
+    names = list(data["names"].values())
+    for *xyxy, conf, cls in reversed(pred):
+        c = int(cls)
+        label = f"{names[c]} {conf:.2f}"
+        annotator.box_label(xyxy, label, color=colors(c, True))
+
+    return annotator.result()
+
+
+def parsing_argument():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model_name",
+        default="yolov3",
+        choices=["yolov3", "yolov3-tiny", "yolov3-spp"],
+        help="available model variations",
+    )
+    parser.add_argument("--all", type=bool, default=False)
+    return parser.parse_args()
+
+
+def main():
+    args = parsing_argument()
+    model_name = args.model_name
+    # Prepare input image
+    img_url = "https://rbln-public.s3.ap-northeast-2.amazonaws.com/images/people4.jpg"
+    img_path = "./people.jpg"
+    with urllib.request.urlopen(img_url) as response, open(img_path, "wb") as f:
+        f.write(response.read())
+    img = cv2.imread(img_path)
+    batch = preprocess(img)
+    batch_tensor = torch.from_numpy(batch)
+
+    # Load model
+    model = attempt_load(model_name + ".pt")
+    model.eval()
+
+    # Disable capturing warnings for torch.compile
+    torch._dynamo.allow_in_graph(warnings.simplefilter)
+
+    def forward_pre_hook(_module, _inputs):
+        warnings.catch_warnings = contextlib.nullcontext
+
+    model.register_forward_pre_hook(forward_pre_hook)
+    # Compile the model
+    torch_module = torch.compile(
+        model,
+        backend="rbln",
+        # Disable dynamic shape support,
+        # as the RBLN backend currently does not support it
+        dynamic=False,
+        options={"cache_dir": f"./{model_name}_cache"},
+    )
+    # (Optional) First call of forward invokes the compilation
+    torch_module(batch_tensor)
+    # After that, You can use models compiled for RBLN hardware
+    result = torch_module(batch_tensor)
+    # Save result
+    rebel_post_output = postprocess(result, batch, img)
+    cv2.imwrite(f"people_{model_name}.jpg", rebel_post_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/pytorch_dynamo/vision/detection/yolov4/main.py
+++ b/pytorch_dynamo/vision/detection/yolov4/main.py
@@ -1,0 +1,98 @@
+import argparse
+import os
+import random
+import sys
+import urllib.request
+
+import cv2
+import numpy as np
+import rebel  # noqa: F401  # needed to use torch dynamo's "rbln" backend.
+import torch
+
+sys.path.append(os.path.join(sys.path[0], "yolov4"))
+from yolov4.models.models import Darknet, load_darknet_weights
+from yolov4.utils.datasets import letterbox
+from yolov4.utils.general import non_max_suppression, scale_coords
+from yolov4.utils.plots import plot_one_box
+
+
+def preprocess(image):
+    preprocess_input = letterbox(image, (640, 640), auto=False)[0]
+    preprocess_input = preprocess_input[:, :, ::-1].transpose(2, 0, 1)
+    preprocess_input = np.ascontiguousarray(preprocess_input, dtype=np.float32)
+    preprocess_input = preprocess_input[None]
+    preprocess_input /= 255
+
+    return preprocess_input
+
+
+def postprocess(outputs, input_image, origin_image):
+    pred = non_max_suppression(outputs, 0.4, 0.5)[0]
+    pred[:, :4] = scale_coords(input_image.shape[2:], pred[:, :4], origin_image.shape).round()
+    names_path = os.path.abspath(os.path.dirname(__file__)) + "/yolov4/data/coco.names"
+    with open(names_path) as f:
+        names = f.read().split("\n")
+        names_list = list(filter(None, names))
+    colors = [[random.randint(0, 255) for _ in range(3)] for _ in range(len(names_list))]
+    for *xyxy, conf, cls in pred:
+        label = "%s %.2f" % (names_list[int(cls)], conf)
+        plot_one_box(xyxy, origin_image, label=label, color=colors[int(cls)], line_thickness=3)
+
+
+def parsing_argument():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model_name",
+        default="yolov4",
+        choices=["yolov4", "yolov4-csp-s-mish", "yolov4-csp-x-mish"],
+        help="available model variations",
+    )
+    parser.add_argument("--all", type=bool, default=False)
+    return parser.parse_args()
+
+
+def main():
+    args = parsing_argument()
+    model_name = args.model_name
+    # Prepare input image
+    img_url = "https://rbln-public.s3.ap-northeast-2.amazonaws.com/images/people4.jpg"
+    img_path = "./people.jpg"
+    with urllib.request.urlopen(img_url) as response, open(img_path, "wb") as f:
+        f.write(response.read())
+    img = cv2.imread(img_path)
+    batch = preprocess(img)
+    batch_tensor = torch.from_numpy(batch)
+
+    # Load model
+    weight = model_name + ".weights"
+    torch.hub.download_url_to_file(
+        f"https://github.com/AlexeyAB/darknet/releases/download/yolov4/{weight}", weight
+    )
+    cfg = os.path.abspath(os.path.dirname(__file__)) + "/yolov4/cfg/" + model_name + ".cfg"
+    model = Darknet(cfg, weight)
+    load_darknet_weights(model, weight)
+    model.eval()
+    # Pre-tracing before torch.compile
+    model(batch_tensor)
+
+    # Compile the model
+    torch.compiler.reset()
+    torch_module = torch.compile(
+        model,
+        backend="rbln",
+        # Disable dynamic shape support, as the RBLN backend currently does not support it
+        dynamic=False,
+        options={"cache_dir": f"./{model_name}_cache"},
+    )
+    # (Optional) First call of forward invokes the compilation
+    torch_module(batch_tensor)
+    # After that, You can use models compiled for RBLN hardware
+    result = torch_module(batch_tensor)
+
+    # Save result
+    postprocess(result[0], batch, img)
+    cv2.imwrite(f"people_{model_name}.jpg", img)
+
+
+if __name__ == "__main__":
+    main()

--- a/pytorch_dynamo/vision/detection/yolov5/main.py
+++ b/pytorch_dynamo/vision/detection/yolov5/main.py
@@ -1,0 +1,103 @@
+import argparse
+import contextlib
+import os
+import sys
+import urllib.request
+import warnings
+
+import cv2
+import numpy as np
+import rebel  # noqa: F401  # needed to use torch dynamo's "rbln" backend.
+import torch
+import yaml
+
+sys.path.insert(0, os.path.join(sys.path[0], "yolov5"))
+from yolov5.utils.augmentations import letterbox
+from yolov5.utils.general import non_max_suppression as nms
+from yolov5.utils.general import scale_boxes
+from yolov5.utils.plots import Annotator, colors
+
+
+def preprocess(image):
+    preprocess_input = letterbox(image, (640, 640), 32, auto=False)[0]
+    preprocess_input = preprocess_input.transpose((2, 0, 1))[::-1]
+    preprocess_input = np.ascontiguousarray(preprocess_input, dtype=np.float32)
+    preprocess_input = preprocess_input[None]
+    preprocess_input /= 255
+
+    return preprocess_input
+
+
+def postprocess(outputs, input_image, origin_image):
+    pred = nms(outputs, 0.25, 0.45, None, False, max_det=1000)[0]
+    annotator = Annotator(origin_image, line_width=3)
+    pred[:, :4] = scale_boxes(input_image.shape[2:], pred[:, :4], origin_image.shape).round()
+    yaml_path = os.path.abspath(os.path.dirname(__file__)) + "/yolov5/data/coco128.yaml"
+    with open(yaml_path) as f:
+        data = yaml.safe_load(f)
+    names = list(data["names"].values())
+    for *xyxy, conf, cls in reversed(pred):
+        c = int(cls)
+        label = f"{names[c]} {conf:.2f}"
+        annotator.box_label(xyxy, label, color=colors(c, True))
+
+    return annotator.result()
+
+
+def parsing_argument():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model_name",
+        default="yolov5s",
+        choices=["yolov5s", "yolov5n", "yolov5m", "yolov5l", "yolov5x"],
+        help="available model variations",
+    )
+    parser.add_argument("--all", type=bool, default=False)
+    return parser.parse_args()
+
+
+def main():
+    args = parsing_argument()
+    model_name = args.model_name
+
+    # Prepare input image
+    img_url = "https://rbln-public.s3.ap-northeast-2.amazonaws.com/images/people4.jpg"
+    img_path = "./people.jpg"
+    with urllib.request.urlopen(img_url) as response, open(img_path, "wb") as f:
+        f.write(response.read())
+    img = cv2.imread(img_path)
+    batch = preprocess(img)
+    batch_tensor = torch.from_numpy(batch)
+
+    # Load model
+    model = torch.hub.load("ultralytics/yolov5", model_name)
+    model.eval()
+
+    # Disable capturing warnings for torch.compile
+    torch._dynamo.allow_in_graph(warnings.simplefilter)
+
+    def forward_pre_hook(_module, _inputs):
+        warnings.catch_warnings = contextlib.nullcontext
+
+    model.register_forward_pre_hook(forward_pre_hook)
+
+    # Compile the model
+    torch_module = torch.compile(
+        model,
+        backend="rbln",
+        # Disable dynamic shape support,
+        # as the RBLN backend currently does not support it
+        dynamic=False,
+        options={"cache_dir": f"./{model_name}_cache"},
+    )
+    # (Optional) First call of forward invokes the compilation
+    torch_module(batch_tensor)
+    # After that, You can use models compiled for RBLN hardware
+    result = torch_module(batch_tensor)
+
+    rebel_post_output = postprocess(result, batch, img)
+    cv2.imwrite(f"people_{model_name}.jpg", rebel_post_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/pytorch_dynamo/vision/detection/yolov6/main.py
+++ b/pytorch_dynamo/vision/detection/yolov6/main.py
@@ -1,0 +1,112 @@
+import argparse
+import contextlib
+import os
+import sys
+import urllib.request
+import warnings
+
+import cv2
+import numpy as np
+import rebel  # noqa: F401  # needed to use torch dynamo's "rbln" backend.
+import torch
+import yaml
+
+sys.path.insert(0, os.path.join(sys.path[0], "YOLOv6"))
+from YOLOv6.yolov6.core.inferer import Inferer
+from YOLOv6.yolov6.data.data_augment import letterbox
+from YOLOv6.yolov6.utils.nms import non_max_suppression as nms
+
+
+def preprocess(image):
+    preprocess_input = letterbox(image, (640, 640), stride=32, auto=False)[0]
+    preprocess_input = preprocess_input.transpose((2, 0, 1))[::-1]
+    preprocess_input = np.ascontiguousarray(preprocess_input, dtype=np.float32)
+    preprocess_input = preprocess_input[None]
+    preprocess_input /= 255
+
+    return preprocess_input
+
+
+def postprocess(outputs, input_image, origin_image):
+    pred = nms(outputs, 0.5, 0.5, None, False, max_det=1000)[0]
+    pred[:, :4] = Inferer.rescale(input_image.shape[2:], pred[:, :4], origin_image.shape).round()
+    yaml_path = os.path.abspath(os.path.dirname(__file__)) + "/YOLOv6/data/coco.yaml"
+    with open(yaml_path) as f:
+        data = yaml.safe_load(f)
+    class_names = data["names"]
+    for *xyxy, conf, cls in reversed(pred):
+        class_num = int(cls)
+        label = f"{class_names[class_num]} {conf:.2f}"
+        Inferer.plot_box_and_label(
+            origin_image,
+            max(round(sum(origin_image.shape) / 2 * 0.003), 2),
+            xyxy,
+            label,
+            color=Inferer.generate_colors(class_num, True),
+        )
+
+
+def parsing_argument():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model_name",
+        default="yolov6s",
+        choices=["yolov6s", "yolov6n", "yolov6m", "yolov6l"],
+        help="available model variations",
+    )
+    parser.add_argument("--all", type=bool, default=False)
+    return parser.parse_args()
+
+
+def main():
+    args = parsing_argument()
+    model_name = args.model_name
+    # Prepare input image
+    img_url = "https://rbln-public.s3.ap-northeast-2.amazonaws.com/images/people4.jpg"
+    img_path = "./people.jpg"
+    with urllib.request.urlopen(img_url) as response, open(img_path, "wb") as f:
+        f.write(response.read())
+    img = cv2.imread(img_path)
+    batch = preprocess(img)
+    batch_tensor = torch.from_numpy(batch)
+
+    # Load model
+    model = torch.hub.load_state_dict_from_url(
+        f"https://github.com/meituan/YOLOv6/releases/download/0.4.0/{model_name}.pt",
+        ".",
+        map_location=torch.device("cpu"),
+    )["model"].float()
+    model.export = True
+    model.eval()
+
+    # Some calls on torch.Tensor in this model return a scalar type.
+    # When this flag is set to True, the scalar is captured instead of a graph break.
+    torch._dynamo.config.capture_scalar_outputs = True
+    # Disable capturing warnings for torch.compile
+    torch._dynamo.allow_in_graph(warnings.simplefilter)
+
+    def forward_pre_hook(_module, _inputs):
+        warnings.catch_warnings = contextlib.nullcontext
+
+    model.register_forward_pre_hook(forward_pre_hook)
+
+    # Compile the model
+    torch_module = torch.compile(
+        model,
+        backend="rbln",
+        # Disable dynamic shape support,
+        # as the RBLN backend currently does not support it
+        dynamic=False,
+        options={"cache_dir": f"./{model_name}_cache"},
+    )
+    # (Optional) First call of forward invokes the compilation
+    torch_module(batch_tensor)
+    # After that, You can use models compiled for RBLN hardware
+    result = torch_module(batch_tensor)
+
+    postprocess(result, batch, img)
+    cv2.imwrite(f"people_{model_name}.jpg", img)
+
+
+if __name__ == "__main__":
+    main()

--- a/pytorch_dynamo/vision/detection/yolox/main.py
+++ b/pytorch_dynamo/vision/detection/yolox/main.py
@@ -6,6 +6,7 @@ from typing import List, Tuple
 
 import cv2
 import numpy as np
+import rebel  # noqa: F401  # needed to use torch dynamo's "rbln" backend.
 import torch
 
 sys.path.insert(0, os.path.join(sys.path[0], "YOLOX"))

--- a/pytorch_dynamo/vision/detection/yolox/main.py
+++ b/pytorch_dynamo/vision/detection/yolox/main.py
@@ -1,0 +1,108 @@
+import argparse
+import os
+import sys
+import urllib.request
+from typing import List, Tuple
+
+import cv2
+import numpy as np
+import torch
+
+sys.path.insert(0, os.path.join(sys.path[0], "YOLOX"))
+from yolox.data.data_augment import ValTransform
+from yolox.data.datasets import COCO_CLASSES
+from yolox.utils import postprocess as postprocessor
+from yolox.utils import vis
+
+
+def preprocess(img: np.array, test_size: List = [640, 640]) -> Tuple[torch.tensor, dict]:
+    ratio = min(test_size[0] / img.shape[0], test_size[1] / img.shape[1])
+    img_info = {"height": img.shape[0], "width": img.shape[1], "ratio": ratio, "raw_img": img}
+    preprocessor = ValTransform(legacy=False)
+    img, _ = preprocessor(img, None, input_size=test_size)
+    img = torch.from_numpy(img).unsqueeze(0).float().to("cpu")
+
+    return img, img_info
+
+
+def visualization(outputs: torch.tensor, img_info: dict, class_names: tuple, result_path: str):
+    if outputs[0] is None:  # no detection result
+        cv2.imwrite(result_path, img_info["raw_img"].copy())
+    else:
+        outputs = outputs[0].cpu()
+        bboxes = outputs[:, 0:4]
+        bboxes /= img_info["ratio"]  # preprocessing: resize
+        cls = outputs[:, 6]
+        scores = outputs[:, 4] * outputs[:, 5]
+        vis_img = vis(
+            img_info["raw_img"].copy(), bboxes, scores, cls, conf=0.35, class_names=class_names
+        )
+        cv2.imwrite(result_path, vis_img)
+
+
+def parsing_argument():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model_name",
+        default="yolox_s",
+        choices=[
+            "yolox_nano",
+            "yolox_tiny",
+            "yolox_s",
+            "yolox_m",
+            "yolox_l",
+            "yolox_x",
+            "yolov3",
+        ],  # yolov3 is YOLOX-Darknet53
+        help="available model variations",
+    )
+
+    return parser.parse_args()
+
+
+def main():
+    args = parsing_argument()
+    model_name = args.model_name
+    input_size = 416 if "nano" in model_name or "tiny" in model_name else 640
+
+    # Prepare input image
+    img_url = "https://rbln-public.s3.ap-northeast-2.amazonaws.com/images/tabby.jpg"
+    img_path = "./tabby.jpg"
+    with urllib.request.urlopen(img_url) as response, open(img_path, "wb") as f:
+        f.write(response.read())
+    img = cv2.imread(img_path)
+    batch, img_info = preprocess(img, test_size=[input_size, input_size])
+    batch = np.ascontiguousarray(batch.numpy(), dtype=np.float32)
+    batch_tensor = torch.from_numpy(batch)
+
+    # Load model
+    model = torch.hub.load("Megvii-BaseDetection/YOLOX", model_name, pretrained=True)
+    model.eval()
+
+    # Compile the model
+    torch_module = torch.compile(
+        model,
+        backend="rbln",
+        # Disable dynamic shape support,
+        # as the RBLN backend currently does not support it
+        dynamic=False,
+        options={"cache_dir": f"./{model_name}_cache"},
+    )
+    # (Optional) First call of forward invokes the compilation
+    torch_module(batch_tensor)
+    # After that, You can use models compiled for RBLN hardware
+    result = torch_module(batch_tensor)
+
+    # Get result image
+    rebel_post_output = postprocessor(
+        torch.tensor(result).to("cpu"),
+        len(COCO_CLASSES),
+        conf_thre=0.25,
+        nms_thre=0.45,
+        class_agnostic=True,
+    )
+    visualization(rebel_post_output, img_info, COCO_CLASSES, result_path=f"tabby_{model_name}.jpg")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR expands our PyTorch Dynamo-based YOLO object detection examples in the model zoo. The update includes implementations for multiple YOLO variants:

- YOLOv3
- YOLOv4
- YOLOv5
- YOLOv6
- YOLOX

These examples demonstrate how to efficiently deploy and run various YOLO architectures on the ATOM NPU using the RBLN SDK with PyTorch's Dynamo compilation. The unified update ensures consistency across implementations and showcases our platform's versatility in handling different YOLO versions for state-of-the-art object detection tasks.

Please Note that this PR should be merged after https://github.com/rebellions-sw/rbln-model-zoo/pull/14 due to dependency issues with submodule files.