### PR TITLE
add model: ViT-large

### DIFF
--- a/huggingface/image-classification/vit/compile.py
+++ b/huggingface/image-classification/vit/compile.py
@@ -1,0 +1,21 @@
+import os
+
+from optimum.rbln import RBLNViTForImageClassification
+
+
+def main():
+    model_id = "google/vit-large-patch16-224"
+
+    # Compile and export
+    model = RBLNViTForImageClassification.from_pretrained(
+        model_id,
+        export=True,  # export a PyTorch model to RBLN model with optimum
+        rbln_batch_size=1,
+    )
+
+    # Save compiled results to disk
+    model.save_pretrained(os.path.basename(model_id))
+
+
+if __name__ == "__main__":
+    main()

--- a/huggingface/image-classification/vit/inference.py
+++ b/huggingface/image-classification/vit/inference.py
@@ -1,0 +1,39 @@
+import os
+import urllib
+
+from optimum.rbln import RBLNViTForImageClassification
+from PIL import Image
+from transformers import ViTFeatureExtractor
+
+
+def main():
+    model_id = "google/vit-large-patch16-224"
+
+    # Load compiled model
+    model = RBLNViTForImageClassification.from_pretrained(
+        model_id=os.path.basename(model_id),
+        export=False,
+    )
+
+    # Prepare inputs
+    img_url = "https://rbln-public.s3.ap-northeast-2.amazonaws.com/images/tabby.jpg"
+    img_path = "./tabby.jpg"
+    if not os.path.exists(img_path):
+        with urllib.request.urlopen(img_url) as response, open(img_path, "wb") as f:
+            f.write(response.read())
+
+    image = Image.open(img_path)
+
+    image_processor = ViTFeatureExtractor.from_pretrained(model_id)
+    inputs = image_processor([image], return_tensors="pt")
+
+    # Run inference
+    logits = model(**inputs)
+    labels = logits.argmax(-1)
+
+    # Show results
+    print("predicted label:", [model.config.id2label[label.item()] for label in labels])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Add ViT-large Model to RBLN Model Zoo

This PR introduces the `ViT-large` model to the RBLN model zoo. The [ViT-large](https://huggingface.co/google/vit-large-patch16-224) (Vision Transformer) model, developed by Google, is designed for image classification tasks and leverages the attention mechanism to effectively process visual inputs.

## Inference Code
Included in this PR is example inference code that demonstrates how to use the ViT-large model optimized on the RBLN NPU. The code includes:

- A **compilation script** that loads the pre-trained model and compiles it for use with the RBLN NPU, exporting the model for inference.
- An **inference script** that loads the compiled model, preprocesses an input image, runs inference, and prints the predicted labels.

This provides users with a clear starting point for deploying ViT-large on their RBLN hardware, showcasing the model's capabilities in real-world image classification scenarios.