### PR TITLE
Update requirements : restriction of numpy version

### DIFF
--- a/huggingface/audio-classification/ast/requirements.txt
+++ b/huggingface/audio-classification/ast/requirements.txt
@@ -4,3 +4,4 @@ optimum-rbln
 torch==2.2.1
 soundfile>=0.12.1
 librosa>=0.10.1
+numpy<2.0.0

--- a/huggingface/depth-estimation/dpt/requirements.txt
+++ b/huggingface/depth-estimation/dpt/requirements.txt
@@ -1,3 +1,4 @@
 --extra-index-url https://pypi.rbln.ai/simple/ https://download.pytorch.org/whl/cpu
 optimum-rbln
 torch==2.2.1
+numpy<2.0.0

--- a/huggingface/embedding-retrieval/bge-m3/dense_embedding/requirements.txt
+++ b/huggingface/embedding-retrieval/bge-m3/dense_embedding/requirements.txt
@@ -1,3 +1,4 @@
 --extra-index-url https://pypi.rbln.ai/simple/ https://download.pytorch.org/whl/cpu
 optimum-rbln
 torch==2.2.1
+numpy<2.0.0

--- a/huggingface/embedding-retrieval/bge-m3/multi_vector/requirements.txt
+++ b/huggingface/embedding-retrieval/bge-m3/multi_vector/requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://pypi.rbln.ai/simple/ https://download.pytorch.org/whl/cpu
 huggingface-hub>=0.23.0
-numpy==1.23.5
 optimum-rbln
 torch==2.2.1
+numpy<2.0.0

--- a/huggingface/embedding-retrieval/bge-m3/sparse_embedding/requirements.txt
+++ b/huggingface/embedding-retrieval/bge-m3/sparse_embedding/requirements.txt
@@ -2,3 +2,4 @@
 huggingface-hub>=0.23.0
 optimum-rbln
 torch==2.2.1
+numpy<2.0.0

--- a/huggingface/embedding-retrieval/bge-reranker/requirements.txt
+++ b/huggingface/embedding-retrieval/bge-reranker/requirements.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://pypi.rbln.ai/simple/
 optimum-rbln
+numpy<2.0.0

--- a/huggingface/embedding-retrieval/e5-base-4k/requirements.txt
+++ b/huggingface/embedding-retrieval/e5-base-4k/requirements.txt
@@ -1,3 +1,4 @@
 --extra-index-url https://pypi.rbln.ai/simple/ https://download.pytorch.org/whl/cpu
 optimum-rbln
 torch==2.2.1
+numpy<2.0.0

--- a/huggingface/fill-mask/securebert/requirements.txt
+++ b/huggingface/fill-mask/securebert/requirements.txt
@@ -1,3 +1,4 @@
 --extra-index-url https://pypi.rbln.ai/simple/ https://download.pytorch.org/whl/cpu
 optimum-rbln
 torch==2.2.1
+numpy<2.0.0

--- a/huggingface/image-classification/resnet/requirements.txt
+++ b/huggingface/image-classification/resnet/requirements.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://pypi.rbln.ai/simple/
 optimum-rbln
+numpy<2.0.0

--- a/huggingface/image-classification/vit/requirements.txt
+++ b/huggingface/image-classification/vit/requirements.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://pypi.rbln.ai/simple/
 optimum-rbln
+numpy<2.0.0

--- a/huggingface/image-to-text/llavanext/requirements.txt
+++ b/huggingface/image-to-text/llavanext/requirements.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://pypi.rbln.ai/simple/
 optimum-rbln
+numpy<2.0.0

--- a/huggingface/question-answering/bert/requirements.txt
+++ b/huggingface/question-answering/bert/requirements.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://pypi.rbln.ai/simple/
 optimum-rbln
+numpy<2.0.0

--- a/huggingface/question-answering/distilbert/requirements.txt
+++ b/huggingface/question-answering/distilbert/requirements.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://pypi.rbln.ai/simple/
 optimum-rbln
+numpy<2.0.0

--- a/huggingface/speech-recognition/wav2vec/requirements.txt
+++ b/huggingface/speech-recognition/wav2vec/requirements.txt
@@ -4,3 +4,4 @@ optimum-rbln
 torch==2.2.1
 soundfile>=0.12.1
 librosa>=0.10.1
+numpy<2.0.0

--- a/huggingface/speech-recognition/whisper/with_token_timestamps/requirements.txt
+++ b/huggingface/speech-recognition/whisper/with_token_timestamps/requirements.txt
@@ -3,3 +3,4 @@ datasets>=2.19.1
 optimum-rbln
 torch==2.2.1
 librosa>=0.10.1
+numpy<2.0.0

--- a/huggingface/speech-recognition/whisper/without_token_timestamps/requirements.txt
+++ b/huggingface/speech-recognition/whisper/without_token_timestamps/requirements.txt
@@ -2,3 +2,4 @@
 datasets>=2.19.1
 optimum-rbln
 librosa>=0.10.1
+numpy<2.0.0

--- a/huggingface/stable-diffusion/stable_diffusion_i2i/requirements.txt
+++ b/huggingface/stable-diffusion/stable_diffusion_i2i/requirements.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://pypi.rbln.ai/simple/
 optimum-rbln
+numpy<2.0.0

--- a/huggingface/stable-diffusion/stable_diffusion_i2i_controlnet/requirements.txt
+++ b/huggingface/stable-diffusion/stable_diffusion_i2i_controlnet/requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://pypi.rbln.ai/simple/ https://download.pytorch.org/whl/cpu
-numpy==1.23.5
 optimum-rbln
 torch==2.2.1
 opencv-python-headless==4.10.0.84
+numpy<2.0.0

--- a/huggingface/stable-diffusion/stable_diffusion_t2i/requirements.txt
+++ b/huggingface/stable-diffusion/stable_diffusion_t2i/requirements.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://pypi.rbln.ai/simple/
 optimum-rbln
+numpy<2.0.0

--- a/huggingface/stable-diffusion/stable_diffusion_xl_i2i/sdxl-base-1.0/requirements.txt
+++ b/huggingface/stable-diffusion/stable_diffusion_xl_i2i/sdxl-base-1.0/requirements.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://pypi.rbln.ai/simple/
 optimum-rbln
+numpy<2.0.0

--- a/huggingface/stable-diffusion/stable_diffusion_xl_i2i/sdxl-turbo/requirements.txt
+++ b/huggingface/stable-diffusion/stable_diffusion_xl_i2i/sdxl-turbo/requirements.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://pypi.rbln.ai/simple/
 optimum-rbln
+numpy<2.0.0

--- a/huggingface/stable-diffusion/stable_diffusion_xl_t2i/sdxl-base-1.0/requirements.txt
+++ b/huggingface/stable-diffusion/stable_diffusion_xl_t2i/sdxl-base-1.0/requirements.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://pypi.rbln.ai/simple/
 optimum-rbln
+numpy<2.0.0

--- a/huggingface/stable-diffusion/stable_diffusion_xl_t2i/sdxl-turbo/requirements.txt
+++ b/huggingface/stable-diffusion/stable_diffusion_xl_t2i/sdxl-turbo/requirements.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://pypi.rbln.ai/simple/
 optimum-rbln
+numpy<2.0.0

--- a/huggingface/text2text-generation/bart/requirements.txt
+++ b/huggingface/text2text-generation/bart/requirements.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://pypi.rbln.ai/simple/
 optimum-rbln
+numpy<2.0.0

--- a/huggingface/text2text-generation/eeve/requirements.txt
+++ b/huggingface/text2text-generation/eeve/requirements.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://pypi.rbln.ai/simple/
 optimum-rbln
+numpy<2.0.0

--- a/huggingface/text2text-generation/exaone/exaone-3-7.8B/requirements.txt
+++ b/huggingface/text2text-generation/exaone/exaone-3-7.8B/requirements.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://pypi.rbln.ai/simple/
 optimum-rbln
+numpy<2.0.0

--- a/huggingface/text2text-generation/gemma/gemma-2b/requirements.txt
+++ b/huggingface/text2text-generation/gemma/gemma-2b/requirements.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://pypi.rbln.ai/simple/
 optimum-rbln
+numpy<2.0.0

--- a/huggingface/text2text-generation/gemma/gemma-7b/requirements.txt
+++ b/huggingface/text2text-generation/gemma/gemma-7b/requirements.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://pypi.rbln.ai/simple/
 optimum-rbln
+numpy<2.0.0

--- a/huggingface/text2text-generation/gpt2/requirements.txt
+++ b/huggingface/text2text-generation/gpt2/requirements.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://pypi.rbln.ai/simple/
 optimum-rbln
+numpy<2.0.0

--- a/huggingface/text2text-generation/kobart/requirements.txt
+++ b/huggingface/text2text-generation/kobart/requirements.txt
@@ -1,3 +1,4 @@
 --extra-index-url https://pypi.rbln.ai/simple/ https://download.pytorch.org/whl/cpu
 optimum-rbln
 torch==2.2.1
+numpy<2.0.0

--- a/huggingface/text2text-generation/llama/llama2-13b/requirements.txt
+++ b/huggingface/text2text-generation/llama/llama2-13b/requirements.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://pypi.rbln.ai/simple/
 optimum-rbln
+numpy<2.0.0

--- a/huggingface/text2text-generation/llama/llama2-7b/requirements.txt
+++ b/huggingface/text2text-generation/llama/llama2-7b/requirements.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://pypi.rbln.ai/simple/
 optimum-rbln
+numpy<2.0.0

--- a/huggingface/text2text-generation/llama/llama3-8b/requirements.txt
+++ b/huggingface/text2text-generation/llama/llama3-8b/requirements.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://pypi.rbln.ai/simple/
 optimum-rbln
+numpy<2.0.0

--- a/huggingface/text2text-generation/midm/requirements.txt
+++ b/huggingface/text2text-generation/midm/requirements.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://pypi.rbln.ai/simple/
 optimum-rbln
+numpy<2.0.0

--- a/huggingface/text2text-generation/mistral/requirements.txt
+++ b/huggingface/text2text-generation/mistral/requirements.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://pypi.rbln.ai/simple/
 optimum-rbln
+numpy<2.0.0

--- a/huggingface/text2text-generation/phi/phi-2/requirements.txt
+++ b/huggingface/text2text-generation/phi/phi-2/requirements.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://pypi.rbln.ai/simple/
 optimum-rbln
+numpy<2.0.0

--- a/huggingface/text2text-generation/qwen2/requirements.txt
+++ b/huggingface/text2text-generation/qwen2/requirements.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://pypi.rbln.ai/simple/
 optimum-rbln
+numpy<2.0.0

--- a/huggingface/text2text-generation/salamandra/requirements.txt
+++ b/huggingface/text2text-generation/salamandra/requirements.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://pypi.rbln.ai/simple/
 optimum-rbln
+numpy<2.0.0

--- a/huggingface/text2text-generation/solar/requirements.txt
+++ b/huggingface/text2text-generation/solar/requirements.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://pypi.rbln.ai/simple/
 optimum-rbln
+numpy<2.0.0

--- a/huggingface/text2text-generation/t5/requirements.txt
+++ b/huggingface/text2text-generation/t5/requirements.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://pypi.rbln.ai/simple/
 optimum-rbln
+numpy<2.0.0

--- a/pytorch/audio/speech_separation/convtasnet/requirements.txt
+++ b/pytorch/audio/speech_separation/convtasnet/requirements.txt
@@ -2,3 +2,4 @@
 mir-eval==0.7
 torch==2.2.1+cpu
 torchaudio==2.2.1+cpu
+numpy<2.0.0

--- a/pytorch/nlp/bert/mlm/requirements.txt
+++ b/pytorch/nlp/bert/mlm/requirements.txt
@@ -1,3 +1,4 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.2.1+cpu
 transformers==4.40.2
+numpy<2.0.0

--- a/pytorch/nlp/bert/qa/requirements.txt
+++ b/pytorch/nlp/bert/qa/requirements.txt
@@ -1,3 +1,4 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.2.1+cpu
 transformers==4.40.2
+numpy<2.0.0

--- a/pytorch/nlp/bge/compute_score/requirements.txt
+++ b/pytorch/nlp/bge/compute_score/requirements.txt
@@ -2,3 +2,4 @@
 torch==2.2.1+cpu
 transformers==4.40.2
 FlagEmbedding==1.2.10
+numpy<2.0.0

--- a/pytorch/nlp/bge/dense_embedding/requirements.txt
+++ b/pytorch/nlp/bge/dense_embedding/requirements.txt
@@ -2,3 +2,4 @@
 torch==2.2.1+cpu
 transformers==4.40.2
 FlagEmbedding==1.2.10
+numpy<2.0.0

--- a/pytorch/nlp/bge/multi_vector/requirements.txt
+++ b/pytorch/nlp/bge/multi_vector/requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-numpy==1.24
 torch==2.2.1+cpu
 transformers==4.40.2
 FlagEmbedding==1.2.10
+numpy<2.0.0

--- a/pytorch/nlp/bge/sparse_embedding/requirements.txt
+++ b/pytorch/nlp/bge/sparse_embedding/requirements.txt
@@ -2,3 +2,4 @@
 torch==2.2.1+cpu
 transformers==4.40.2
 FlagEmbedding==1.2.10
+numpy<2.0.0

--- a/pytorch/vision/detection/yolov7/requirements.txt
+++ b/pytorch/vision/detection/yolov7/requirements.txt
@@ -7,3 +7,4 @@ torchvision==0.17.1+cpu
 opencv-python-headless==4.10.0.84
 pyyaml==6.0.1
 seaborn==0.12.1
+requests==2.32.3

--- a/pytorch/vision/image_classification/deit/requirements.txt
+++ b/pytorch/vision/image_classification/deit/requirements.txt
@@ -2,3 +2,4 @@
 timm>=0.9.16
 torch==2.2.1+cpu
 torchvision==0.17.1+cpu
+numpy<2.0.0

--- a/pytorch/vision/image_classification/torchvision/requirements.txt
+++ b/pytorch/vision/image_classification/torchvision/requirements.txt
@@ -1,3 +1,4 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.2.1+cpu
 torchvision==0.17.1+cpu
+numpy<2.0.0

--- a/pytorch/vision/segmentation/torchvision/requirements.txt
+++ b/pytorch/vision/segmentation/torchvision/requirements.txt
@@ -1,3 +1,4 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.2.1+cpu
 torchvision==0.17.1+cpu
+numpy<2.0.0


### PR DESCRIPTION
In this PR, packages that have torchvision as a dependency will be downgraded to numpy<2.0.0 immediately after installing the package. 