### PR TITLE
[Release] 02 Jul 2025

### DIFF
--- a/cpp/image_classification/requirements.txt
+++ b/cpp/image_classification/requirements.txt
@@ -1,2 +1,2 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torchvision<=0.21.0
+torchvision<=0.22.0

--- a/cpp/object_detection/requirements.txt
+++ b/cpp/object_detection/requirements.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.6.0
+torch==2.7.0
 ultralytics==8.3.33

--- a/huggingface/diffusers/text-to-image/stable_diffusion_t2i/sd-v1.5-lcm-lora/requirements.txt
+++ b/huggingface/diffusers/text-to-image/stable_diffusion_t2i/sd-v1.5-lcm-lora/requirements.txt
@@ -1,2 +1,2 @@
 optimum-rbln
-peft<=0.13.2
+peft>=0.15.0

--- a/huggingface/diffusers/text-to-image/stable_diffusion_xl_t2i/sdxl-base-1.0-pixel-lora/requirements.txt
+++ b/huggingface/diffusers/text-to-image/stable_diffusion_xl_t2i/sdxl-base-1.0-pixel-lora/requirements.txt
@@ -1,2 +1,2 @@
 optimum-rbln
-peft<=0.13.2
+peft>=0.15.0

--- a/huggingface/transformers/sentence-similarity/sentence-t5-xxl/requirements.txt
+++ b/huggingface/transformers/sentence-similarity/sentence-t5-xxl/requirements.txt
@@ -1,3 +1,3 @@
 optimum-rbln
-huggingface_hub==0.30.2
+huggingface-hub>=0.23.0
 sentence-transformers==3.4.1

--- a/huggingface/transformers/text2text-generation/llama/fingpt-mt-llama3-8b-lora/requirements.txt
+++ b/huggingface/transformers/text2text-generation/llama/fingpt-mt-llama3-8b-lora/requirements.txt
@@ -1,2 +1,2 @@
 optimum-rbln
-peft<=0.13.2
+peft>=0.15.0

--- a/pytorch/audio/speech_separation/convtasnet/requirements.txt
+++ b/pytorch/audio/speech_separation/convtasnet/requirements.txt
@@ -1,4 +1,4 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 mir-eval==0.7
-torch==2.6.0
-torchaudio<=2.6.0
+torch==2.7.0
+torchaudio<=2.7.0

--- a/pytorch/nlp/bert/mlm/requirements.txt
+++ b/pytorch/nlp/bert/mlm/requirements.txt
@@ -1,4 +1,4 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.6.0
+torch==2.7.0
 transformers==4.50.3
 numpy<2.0.0

--- a/pytorch/nlp/bert/qa/requirements.txt
+++ b/pytorch/nlp/bert/qa/requirements.txt
@@ -1,4 +1,4 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.6.0
+torch==2.7.0
 transformers==4.50.3
 numpy<2.0.0

--- a/pytorch/nlp/bge/compute_score/requirements.txt
+++ b/pytorch/nlp/bge/compute_score/requirements.txt
@@ -1,4 +1,4 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.6.0
+torch==2.7.0
 transformers==4.50.3
 FlagEmbedding==1.2.10

--- a/pytorch/nlp/bge/dense_embedding/requirements.txt
+++ b/pytorch/nlp/bge/dense_embedding/requirements.txt
@@ -1,4 +1,4 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.6.0
+torch==2.7.0
 transformers==4.50.3
 FlagEmbedding==1.2.10

--- a/pytorch/nlp/bge/multi_vector/requirements.txt
+++ b/pytorch/nlp/bge/multi_vector/requirements.txt
@@ -1,4 +1,4 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.6.0
+torch==2.7.0
 transformers==4.50.3
 FlagEmbedding==1.2.10

--- a/pytorch/nlp/bge/sparse_embedding/requirements.txt
+++ b/pytorch/nlp/bge/sparse_embedding/requirements.txt
@@ -1,4 +1,4 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.6.0
+torch==2.7.0
 transformers==4.50.3
 FlagEmbedding==1.2.10

--- a/pytorch/nlp/labse/requirements.txt
+++ b/pytorch/nlp/labse/requirements.txt
@@ -1,4 +1,4 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.6.0
+torch==2.7.0
 transformers==4.50.3
 sentence-transformers==3.4.1

--- a/pytorch/vision/action_recognition/motionbert/requirements.txt
+++ b/pytorch/vision/action_recognition/motionbert/requirements.txt
@@ -5,5 +5,5 @@ ipdb==0.13.13
 matplotlib>=3.8.0
 scipy>=1.10.1
 smplx==0.1.28
-torch==2.6.0
+torch==2.7.0
 pyyaml>=6.0.1

--- a/pytorch/vision/detection/yolov10/requirements.txt
+++ b/pytorch/vision/detection/yolov10/requirements.txt
@@ -1,8 +1,8 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 matplotlib>=3.8.0
 scipy>=1.10.1
-torch==2.6.0
-torchvision<=0.21.0
+torch==2.7.0
+torchvision<=0.22.0
 opencv-python-headless==4.10.0.84
 pyyaml>=6.0.1
 requests==2.32.3

--- a/pytorch/vision/detection/yolov3/requirements.txt
+++ b/pytorch/vision/detection/yolov3/requirements.txt
@@ -1,8 +1,8 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 matplotlib>=3.8.0
 scipy>=1.10.1
-torch==2.6.0
-torchvision<=0.21.0
+torch==2.7.0
+torchvision<=0.22.0
 opencv-python-headless==4.10.0.84
 requests==2.32.3
 pyyaml>=6.0.1

--- a/pytorch/vision/detection/yolov4/requirements.txt
+++ b/pytorch/vision/detection/yolov4/requirements.txt
@@ -1,8 +1,8 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 matplotlib>=3.8.0
 scipy>=1.10.1
-torch==2.6.0
-torchvision<=0.21.0
+torch==2.7.0
+torchvision<=0.22.0
 opencv-python-headless==4.10.0.84
 pyyaml>=6.0.1
 pycocotools>=2.0.7

--- a/pytorch/vision/detection/yolov5/requirements.txt
+++ b/pytorch/vision/detection/yolov5/requirements.txt
@@ -1,6 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 matplotlib>=3.8.0
 scipy>=1.10.1
-torch==2.6.0
-torchvision<=0.21.0
+torch==2.7.0
+torchvision<=0.22.0
 ultralytics==8.3.33

--- a/pytorch/vision/detection/yolov6/requirements.txt
+++ b/pytorch/vision/detection/yolov6/requirements.txt
@@ -1,8 +1,8 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 matplotlib>=3.8.0
 pycocotools>=2.0.7
-torch==2.6.0
-torchvision<=0.21.0
+torch==2.7.0
+torchvision<=0.22.0
 opencv-python-headless==4.10.0.84
 pyyaml>=6.0.1
 requests==2.32.3

--- a/pytorch/vision/detection/yolov7/requirements.txt
+++ b/pytorch/vision/detection/yolov7/requirements.txt
@@ -1,8 +1,8 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 matplotlib>=3.8.0
 scipy>=1.10.1
-torch==2.6.0
-torchvision<=0.21.0
+torch==2.7.0
+torchvision<=0.22.0
 opencv-python-headless==4.10.0.84
 pyyaml>=6.0.1
 seaborn>=0.13.2

--- a/pytorch/vision/detection/yolov8/requirements.txt
+++ b/pytorch/vision/detection/yolov8/requirements.txt
@@ -1,8 +1,8 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 matplotlib>=3.8.0
 scipy>=1.10.1
-torch==2.6.0
-torchvision<=0.21.0
+torch==2.7.0
+torchvision<=0.22.0
 opencv-python-headless==4.10.0.84
 pyyaml>=6.0.1
 requests==2.32.3

--- a/pytorch/vision/detection/yolox/requirements.txt
+++ b/pytorch/vision/detection/yolox/requirements.txt
@@ -2,6 +2,6 @@
 loguru==0.6.0
 pycocotools>=2.0.7
 tabulate==0.9.0
-torch==2.6.0
-torchvision<=0.21.0
+torch==2.7.0
+torchvision<=0.22.0
 opencv-python-headless==4.10.0.84

--- a/pytorch/vision/face_detection/yolov5-face/requirements.txt
+++ b/pytorch/vision/face_detection/yolov5-face/requirements.txt
@@ -1,8 +1,8 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 matplotlib>=3.8.0
 scipy>=1.10.1
-torch==2.6.0
-torchvision<=0.21.0
+torch==2.7.0
+torchvision<=0.22.0
 opencv-python-headless==4.10.0.84
 pyyaml>=6.0.1
 pandas>=2.2.2

--- a/pytorch/vision/image_classification/deit/requirements.txt
+++ b/pytorch/vision/image_classification/deit/requirements.txt
@@ -1,4 +1,4 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 timm>=0.9.16
-torch==2.6.0
-torchvision<=0.21.0
+torch==2.7.0
+torchvision<=0.22.0

--- a/pytorch/vision/image_classification/torchvision/requirements.txt
+++ b/pytorch/vision/image_classification/torchvision/requirements.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.6.0
-torchvision<=0.21.0
+torch==2.7.0
+torchvision<=0.22.0

--- a/pytorch/vision/pose_estimation/motionbert/requirements.txt
+++ b/pytorch/vision/pose_estimation/motionbert/requirements.txt
@@ -5,7 +5,7 @@ matplotlib>=3.8.0
 scipy>=1.10.1
 smplx==0.1.28
 imageio_ffmpeg==0.4.9
-torch==2.6.0
+torch==2.7.0
 pyyaml>=6.0.1
 imageio==2.34.1
 opencv-python-headless==4.10.0.84

--- a/pytorch/vision/segmentation/torchvision/requirements.txt
+++ b/pytorch/vision/segmentation/torchvision/requirements.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.6.0
-torchvision<=0.21.0
+torch==2.7.0
+torchvision<=0.22.0

--- a/pytorch/vision/segmentation/unet/requirements.txt
+++ b/pytorch/vision/segmentation/unet/requirements.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.6.0
+torch==2.7.0
 pillow>=10.2.0

--- a/pytorch/vision/video_classification/torchvision/requirements.txt
+++ b/pytorch/vision/video_classification/torchvision/requirements.txt
@@ -1,4 +1,4 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.6.0
-torchvision<=0.21.0
+torch==2.7.0
+torchvision<=0.22.0
 av>=11.0.0

--- a/pytorch_dynamo/audio/speech_separation/convtasnet/main.py
+++ b/pytorch_dynamo/audio/speech_separation/convtasnet/main.py
@@ -8,9 +8,6 @@ from metric import sdri
 from mir_eval import separation
 from torchaudio.pipelines import CONVTASNET_BASE_LIBRI2MIX
 
-if torch.__version__ >= "2.5.0":
-    torch._dynamo.config.inline_inbuilt_nn_modules = False
-
 
 def sisdri_metric(
     estimate: torch.Tensor, reference: torch.Tensor, mix: torch.Tensor, mask: torch.Tensor

--- a/pytorch_dynamo/audio/speech_separation/convtasnet/requirements.txt
+++ b/pytorch_dynamo/audio/speech_separation/convtasnet/requirements.txt
@@ -1,4 +1,4 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 mir-eval==0.7
-torch==2.6.0
-torchaudio<=2.6.0
+torch==2.7.0
+torchaudio<=2.7.0

--- a/pytorch_dynamo/nlp/bert/mlm/main.py
+++ b/pytorch_dynamo/nlp/bert/mlm/main.py
@@ -5,9 +5,6 @@ import rebel  # noqa: F401  # needed to use torch dynamo's "rbln" backend
 import torch
 from transformers import BertForMaskedLM, BertTokenizer
 
-if torch.__version__ >= "2.5.0":
-    torch._dynamo.config.inline_inbuilt_nn_modules = False
-
 
 def parsing_argument():
     parser = argparse.ArgumentParser()

--- a/pytorch_dynamo/nlp/bert/mlm/requirements.txt
+++ b/pytorch_dynamo/nlp/bert/mlm/requirements.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.6.0
+torch==2.7.0
 transformers==4.50.3

--- a/pytorch_dynamo/nlp/bert/qa/main.py
+++ b/pytorch_dynamo/nlp/bert/qa/main.py
@@ -5,9 +5,6 @@ import rebel  # noqa: F401  # needed to use torch dynamo's "rbln" backend
 import torch
 from transformers import BertForQuestionAnswering, BertTokenizer
 
-if torch.__version__ >= "2.5.0":
-    torch._dynamo.config.inline_inbuilt_nn_modules = False
-
 
 def parsing_argument():
     parser = argparse.ArgumentParser()

--- a/pytorch_dynamo/nlp/bert/qa/requirements.txt
+++ b/pytorch_dynamo/nlp/bert/qa/requirements.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.6.0
+torch==2.7.0
 transformers==4.50.3

--- a/pytorch_dynamo/vision/detection/yolov3/main.py
+++ b/pytorch_dynamo/vision/detection/yolov3/main.py
@@ -11,9 +11,6 @@ import rebel  # noqa: F401  # needed to use torch dynamo's "rbln" backend.
 import torch
 import yaml
 
-if torch.__version__ >= "2.5.0":
-    torch._dynamo.config.inline_inbuilt_nn_modules = False
-
 sys.path.append(os.path.join(sys.path[0], "yolov3"))
 sys.path.append(os.path.join(sys.path[0], "ultralytics"))
 from yolov3.models.experimental import attempt_load

--- a/pytorch_dynamo/vision/detection/yolov3/requirements.txt
+++ b/pytorch_dynamo/vision/detection/yolov3/requirements.txt
@@ -2,8 +2,8 @@
 matplotlib>=3.8.0
 pycocotools>=2.0.7
 scipy>=1.10.1
-torch==2.6.0
-torchvision<=0.21.0
+torch==2.7.0
+torchvision<=0.22.0
 opencv-python-headless==4.10.0.84
 requests==2.32.3
 pyyaml>=6.0.1

--- a/pytorch_dynamo/vision/detection/yolov4/main.py
+++ b/pytorch_dynamo/vision/detection/yolov4/main.py
@@ -9,9 +9,6 @@ import numpy as np
 import rebel  # noqa: F401  # needed to use torch dynamo's "rbln" backend.
 import torch
 
-if torch.__version__ >= "2.5.0":
-    torch._dynamo.config.inline_inbuilt_nn_modules = False
-
 sys.path.append(os.path.join(sys.path[0], "yolov4"))
 from yolov4.models.models import Darknet, load_darknet_weights
 from yolov4.utils.datasets import letterbox

--- a/pytorch_dynamo/vision/detection/yolov4/requirements.txt
+++ b/pytorch_dynamo/vision/detection/yolov4/requirements.txt
@@ -2,7 +2,7 @@
 matplotlib>=3.8.0
 pycocotools>=2.0.7
 scipy>=1.10.1
-torch==2.6.0
-torchvision<=0.21.0
+torch==2.7.0
+torchvision<=0.22.0
 opencv-python-headless==4.10.0.84
 pyyaml>=6.0.1

--- a/pytorch_dynamo/vision/detection/yolov5/main.py
+++ b/pytorch_dynamo/vision/detection/yolov5/main.py
@@ -11,9 +11,6 @@ import rebel  # noqa: F401  # needed to use torch dynamo's "rbln" backend.
 import torch
 import yaml
 
-if torch.__version__ >= "2.5.0":
-    torch._dynamo.config.inline_inbuilt_nn_modules = False
-
 sys.path.insert(0, os.path.join(sys.path[0], "yolov5"))
 from yolov5.utils.augmentations import letterbox
 from yolov5.utils.general import non_max_suppression as nms, scale_boxes

--- a/pytorch_dynamo/vision/detection/yolov5/requirements.txt
+++ b/pytorch_dynamo/vision/detection/yolov5/requirements.txt
@@ -2,6 +2,6 @@
 matplotlib>=3.8.0
 pycocotools>=2.0.7
 scipy>=1.10.1
-torch==2.6.0
-torchvision<=0.21.0
+torch==2.7.0
+torchvision<=0.22.0
 ultralytics==8.3.33

--- a/pytorch_dynamo/vision/detection/yolov6/main.py
+++ b/pytorch_dynamo/vision/detection/yolov6/main.py
@@ -11,9 +11,6 @@ import rebel  # noqa: F401  # needed to use torch dynamo's "rbln" backend.
 import torch
 import yaml
 
-if torch.__version__ >= "2.5.0":
-    torch._dynamo.config.inline_inbuilt_nn_modules = False
-
 sys.path.insert(0, os.path.join(sys.path[0], "YOLOv6"))
 from YOLOv6.yolov6.core.inferer import Inferer
 from YOLOv6.yolov6.data.data_augment import letterbox

--- a/pytorch_dynamo/vision/detection/yolov6/requirements.txt
+++ b/pytorch_dynamo/vision/detection/yolov6/requirements.txt
@@ -1,8 +1,8 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 matplotlib>=3.8.0
 pycocotools>=2.0.7
-torch==2.6.0
-torchvision<=0.21.0
+torch==2.7.0
+torchvision<=0.22.0
 opencv-python-headless==4.10.0.84
 pyyaml>=6.0.1
 requests==2.32.3

--- a/pytorch_dynamo/vision/detection/yolox/main.py
+++ b/pytorch_dynamo/vision/detection/yolox/main.py
@@ -9,9 +9,6 @@ import numpy as np
 import rebel  # noqa: F401  # needed to use torch dynamo's "rbln" backend.
 import torch
 
-if torch.__version__ >= "2.5.0":
-    torch._dynamo.config.inline_inbuilt_nn_modules = False
-
 sys.path.insert(0, os.path.join(sys.path[0], "YOLOX"))
 from yolox.data.data_augment import ValTransform
 from yolox.data.datasets import COCO_CLASSES

--- a/pytorch_dynamo/vision/detection/yolox/requirements.txt
+++ b/pytorch_dynamo/vision/detection/yolox/requirements.txt
@@ -2,6 +2,6 @@
 loguru==0.6.0
 pycocotools>=2.0.7
 tabulate==0.9.0
-torch==2.6.0
-torchvision<=0.21.0
+torch==2.7.0
+torchvision<=0.22.0
 opencv-python-headless==4.10.0.84

--- a/pytorch_dynamo/vision/image_classification/deit/main.py
+++ b/pytorch_dynamo/vision/image_classification/deit/main.py
@@ -6,9 +6,6 @@ import torch
 import torchvision.transforms as transforms
 from torchvision.io.image import read_image
 
-if torch.__version__ >= "2.5.0":
-    torch._dynamo.config.inline_inbuilt_nn_modules = False
-
 model_map = {
     "tiny": "deit_tiny_patch16_224",
     "small": "deit_small_patch16_224",

--- a/pytorch_dynamo/vision/image_classification/deit/requirements.txt
+++ b/pytorch_dynamo/vision/image_classification/deit/requirements.txt
@@ -1,4 +1,4 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 timm>=0.9.16
-torch==2.6.0
-torchvision<=0.21.0
+torch==2.7.0
+torchvision<=0.22.0

--- a/pytorch_dynamo/vision/image_classification/torchvision/main.py
+++ b/pytorch_dynamo/vision/image_classification/torchvision/main.py
@@ -6,9 +6,6 @@ import torch
 import torchvision
 from torchvision.io.image import read_image
 
-if torch.__version__ >= "2.5.0":
-    torch._dynamo.config.inline_inbuilt_nn_modules = False
-
 
 def parsing_argument():
     parser = argparse.ArgumentParser()

--- a/pytorch_dynamo/vision/image_classification/torchvision/requirements.txt
+++ b/pytorch_dynamo/vision/image_classification/torchvision/requirements.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.6.0
-torchvision<=0.21.0
+torch==2.7.0
+torchvision<=0.22.0

--- a/pytorch_dynamo/vision/segmentation/sam2/main.py
+++ b/pytorch_dynamo/vision/segmentation/sam2/main.py
@@ -10,9 +10,6 @@ import requests
 import torch
 from PIL import Image
 
-if torch.__version__ >= "2.5.0":
-    torch._dynamo.config.inline_inbuilt_nn_modules = False
-
 sys.path.insert(0, os.path.join(sys.path[0], "sam2"))
 
 import rebel  # noqa: F401  # needed to use torch dynamo's "rbln" backend

--- a/pytorch_dynamo/vision/segmentation/sam2/requirements.txt
+++ b/pytorch_dynamo/vision/segmentation/sam2/requirements.txt
@@ -1,8 +1,8 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 matplotlib>=3.8.0
-torch==2.6.0
+torch==2.7.0
 opencv-python-headless==4.10.0.84
 hydra-core==1.3.2
-torchvision<=0.21.0
+torchvision<=0.22.0
 iopath==0.1.10
 requests==2.32.3

--- a/pytorch_dynamo/vision/segmentation/torchvision/main.py
+++ b/pytorch_dynamo/vision/segmentation/torchvision/main.py
@@ -7,9 +7,6 @@ import torchvision
 from PIL import Image
 from torchvision import transforms
 
-if torch.__version__ >= "2.5.0":
-    torch._dynamo.config.inline_inbuilt_nn_modules = False
-
 model_weights_map = {
     "fcn_resnet50": "FCN_ResNet50_Weights",
     "fcn_resnet101": "FCN_ResNet101_Weights",

--- a/pytorch_dynamo/vision/segmentation/torchvision/requirements.txt
+++ b/pytorch_dynamo/vision/segmentation/torchvision/requirements.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.6.0
-torchvision<=0.21.0
+torch==2.7.0
+torchvision<=0.22.0

--- a/pytorch_dynamo/vision/video_classification/torchvision/main.py
+++ b/pytorch_dynamo/vision/video_classification/torchvision/main.py
@@ -6,9 +6,6 @@ import torch
 import torchvision
 from torchvision.io.video import read_video
 
-if torch.__version__ >= "2.5.0":
-    torch._dynamo.config.inline_inbuilt_nn_modules = False
-
 
 def parsing_argument():
     parser = argparse.ArgumentParser()

--- a/pytorch_dynamo/vision/video_classification/torchvision/requirements.txt
+++ b/pytorch_dynamo/vision/video_classification/torchvision/requirements.txt
@@ -1,4 +1,4 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.6.0
-torchvision<=0.21.0
+torch==2.7.0
+torchvision<=0.22.0
 av>=11.0.0


### PR DESCRIPTION
# [Release] 02 Jul 2025

## ✨ Added
| Area | Description |
|------|-------------|
| — | *No new models or pipelines were introduced in this release.* |

---

## 🔄 Changed

### Framework &amp; Dependencies
* **Upgrade to the 2.7 stack** – all pipelines now target **Torch 2.7.0**, **TorchVision ≤ 0.22.0**, and (where used) **TorchAudio ≤ 2.7.0**.  
  *Files touched:* every `requirements.txt` under **cpp**, **pytorch**, and **pytorch_dynamo**.
* **PEFT &amp; HF Hub modernised**  
  * `peft<=0.13.2` → **`peft>=0.15.0`**  
  * `huggingface_hub==0.30.2` → **`huggingface-hub>=0.23.0`**

### Codebase Polish
* **Model-level config guard removed** – example scripts no longer include  
  ```python
  if torch.__version__ >= "2.5.0":
      torch._dynamo.config.inline_inbuilt_nn_modules = False
</code></pre>
<p>The setting is now applied once centrally inside <strong>RBLN-SDK</strong>.</p>
<ul>
</ul>
<h3>Model-specific Tweaks</h3>
<ul>
<li>
<p><strong>MotionBERT, DeIT, BGE, LabSE, ConvTasNet, SAM-2, UNet</strong> and every YOLO flavour inherit the Torch 2.7 / TorchVision 0.22 bump.</p>
</li>
<li>
<p><strong>Sentence-T5-XXL</strong> now uses the canonical <code inline="">huggingface-hub</code> package name.</p>
</li>
<li>
<p><strong>Stable-Diffusion LoRA (v1.5 &amp; SD-XL)</strong> and <strong>FingPT-Llama3-LoRA</strong> adopt <code inline="">peft&gt;=0.15.0</code>.</p>
</li>
</ul>
<hr>
<h2>📦 Requirements Matrix (before → after)</h2>

Package | Old | New
-- | -- | --
torch | 2.6.0 | 2.7.0
torchvision | ≤ 0.21.0 | ≤ 0.22.0
torchaudio | ≤ 2.6.0 | ≤ 2.7.0
peft | ≤ 0.13.2 | ≥ 0.15.0
huggingface-hub | 0.30.2 | ≥ 0.23.0


<hr>
<h2>⚙️ Migration Notes</h2>
<ol>
<li>
<p>Re-create your virtual environment or simply run:</p>
<pre><code class="language-bash">pip install -U -r requirements.txt
</code></pre>
</li>
<li>
<p><strong>Docker images</strong> – ensure your base image (Ubuntu 22.04 / 24.04) pulls Torch 2.7 wheels.</p>
</li>
<li>
<p><strong>Custom scripts</strong> – you can delete any local copies of the <code inline="">inline_inbuilt_nn_modules</code> guard; <strong>RBLN-SDK</strong> now handles it globally.</p>
</li>
</ol>
<hr>