### PR TITLE
fix: explicitly set output filename

### DIFF
--- a/huggingface/diffusers/text-to-video/cosmos-14b/inference.py
+++ b/huggingface/diffusers/text-to-video/cosmos-14b/inference.py
@@ -124,7 +124,7 @@ def main():
 
     # Inference with upsampled text and Generate video from text
     output = pipe(prompt=upsampled_prompt).frames[0]
-    export_to_video(output, f"{args.text}.mp4", fps=30)
+    export_to_video(output, "t2w_14b.mp4", fps=30)
 
 
 if __name__ == "__main__":

--- a/huggingface/diffusers/text-to-video/cosmos-7b/inference.py
+++ b/huggingface/diffusers/text-to-video/cosmos-7b/inference.py
@@ -124,7 +124,7 @@ def main():
 
     # Inference with upsampled text and Generate video from text
     output = pipe(prompt=upsampled_prompt).frames[0]
-    export_to_video(output, f"{args.text}.mp4", fps=30)
+    export_to_video(output, "t2w_7b.mp4", fps=30)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Update output filenames to prevent issues due to the length of filename.