### PR TITLE
fix: resolve error while setting ckpt_path in cosmos-transfer1

### DIFF
--- a/huggingface/third-party-models/video-to-video/cosmos_transfer1/compile_transfer_multiview_impl.py
+++ b/huggingface/third-party-models/video-to-video/cosmos_transfer1/compile_transfer_multiview_impl.py
@@ -116,6 +116,9 @@ def validate_controlnet_specs(cfg, controlnet_specs):
                 config["ckpt_path"] = os.path.join(
                     checkpoint_dir, default_model_names[hint_key]
                 )
+            elif not os.path.exists(config["ckpt_path"]):
+                ckpt_path = os.path.join(checkpoint_dir, config["ckpt_path"])
+                config["ckpt_path"] = ckpt_path
 
             # Regardless whether "control_weight_prompt" is provided (i.e. whether we automatically
             # generate spatiotemporal control weight binary masks), control_weight is needed to.

--- a/huggingface/third-party-models/video-to-video/cosmos_transfer1/rbln_inference/inference_utils.py
+++ b/huggingface/third-party-models/video-to-video/cosmos_transfer1/rbln_inference/inference_utils.py
@@ -1454,6 +1454,9 @@ def validate_controlnet_specs(cfg, controlnet_specs) -> Dict[str, Any]:
 
             config["ckpt_path"] = ckpt_path
             log.info(f"Using default checkpoint path: {config['ckpt_path']}")
+        elif not os.path.exists(config["ckpt_path"]):
+            ckpt_path = os.path.join(checkpoint_dir, config["ckpt_path"])
+            config["ckpt_path"] = ckpt_path
 
         # Regardless whether "control_weight_prompt" is provided (i.e. whether we automatically
         # generate spatiotemporal control weight binary masks), control_weight is needed to.

--- a/huggingface/third-party-models/video-to-video/cosmos_transfer1/rbln_inference/rbln_pipeline.py
+++ b/huggingface/third-party-models/video-to-video/cosmos_transfer1/rbln_inference/rbln_pipeline.py
@@ -795,7 +795,7 @@ class RBLNDiffusionControl2WorldGenerationPipeline:
                 n_views = 1 if not hasattr(model, "n_views") else model.n_views
 
                 model.tensor_kwargs = {"device": "cpu", "dtype": torch.float32}
-                ckpt_path = os.path.join(self.checkpoint_dir, spec["ckpt_path"])
+                ckpt_path = spec["ckpt_path"]
 
                 log.info(f"Loading ctrl model from ckpt_path: {spec['ckpt_path']}")
                 with skip_init_linear():
@@ -968,7 +968,7 @@ class RBLNDiffusionControl2WorldGenerationPipeline:
                 )
 
                 model.tensor_kwargs = {"device": "cpu", "dtype": torch.float32}
-                ckpt_path = os.path.join(self.checkpoint_dir, spec["ckpt_path"])
+                ckpt_path = spec["ckpt_path"]
 
                 log.info(f"Loading ctrl model from ckpt_path: {spec['ckpt_path']}")
                 with skip_init_linear():
@@ -2176,7 +2176,7 @@ class RBLNDistilledControl2WorldGenerationPipeline(
         )
 
         for _, config in self.control_inputs.items():
-            checkpoint_path = os.path.join(self.checkpoint_dir, config["ckpt_path"])
+            checkpoint_path = config["ckpt_path"]
 
         log.info(f"Loading base model and ctrl model from ckpt_path: {checkpoint_path}")
         checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
@@ -2315,7 +2315,7 @@ class RBLNDistilledControl2WorldGenerationPipeline(
         )
 
         for _, config in self.control_inputs.items():
-            checkpoint_path = os.path.join(self.checkpoint_dir, config["ckpt_path"])
+            checkpoint_path = config["ckpt_path"]
 
         log.info(f"Loading base model and ctrl model from ckpt_path: {checkpoint_path}")
         checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=False)


### PR DESCRIPTION
- Remove redundant join while set `ckpt_path`
- Join `checkpoint_dir` and `ckpt_path` when `ckpt_path` is explicitly set in controlnet_spec