### PR TITLE
docs(pose_estimation): remove internal note from compile scripts

### DIFF
--- a/pytorch/vision/pose_estimation/yolov11/compile.py
+++ b/pytorch/vision/pose_estimation/yolov11/compile.py
@@ -12,9 +12,6 @@ from ultralytics.nn.modules.head import Pose
 
 
 def _kpts_decode_traceable(self, bs, kpts):
-    # Decode keypoints with view + fixed-dim select + stack so the whole
-    # post-head transform stays on the NPU instead of falling back to
-    # host scatter_elements/strided_slice TVM ops.
     nkpt, ndim = self.kpt_shape
     n = kpts.shape[-1]
     y = kpts.view(bs, nkpt, ndim, n)

--- a/pytorch/vision/pose_estimation/yolov8/compile.py
+++ b/pytorch/vision/pose_estimation/yolov8/compile.py
@@ -12,9 +12,6 @@ from ultralytics.nn.modules.head import Pose
 
 
 def _kpts_decode_traceable(self, bs, kpts):
-    # Decode keypoints with view + fixed-dim select + stack so the whole
-    # post-head transform stays on the NPU instead of falling back to
-    # host scatter_elements/strided_slice TVM ops.
     nkpt, ndim = self.kpt_shape
     n = kpts.shape[-1]
     y = kpts.view(bs, nkpt, ndim, n)


### PR DESCRIPTION
## Summary
- Remove an internal compiler implementation-detail comment from the `_kpts_decode_traceable` helper in the YOLOv8 and YOLOv11 pose-estimation `compile.py` scripts.
- The note described internal op-placement behavior that is not relevant to these public examples and can be misleading to users following them.

## Changes
- `pytorch/vision/pose_estimation/yolov8/compile.py`
- `pytorch/vision/pose_estimation/yolov11/compile.py`
