### PR TITLE
[Release] Aug. 28, 2026

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.swp
 *.swo
-.pkl_memoize_py3
+*.so
+*.meta
 *.rbln
 *.log
 *.jpg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Change Log
 
+## August, 28th 2026 (v0.11.2)
+
+* Compatible versions:
+  * `rebel-compiler`: v0.11.2
+  * `optimum-rbln`: v0.11.2
+  * `vllm-rbln`: v0.11.2
+  * `docs.rbln.ai`: v0.11.2
+* **Added new examples**
+  * `image-text-to-text`: **Qwen3.8 (27B)**.
+  * `fill-mask`: **ModernBERT** — first fill-mask example in the zoo.
+* **Changes**
+  * Diffusers: all compile scripts now pass an explicit `torch_dtype=torch.float16` to `from_pretrained` (plus `variant="fp16"` where the checkpoint publishes fp16 weight shards). Diffusers loads weights as fp32 unless `torch_dtype` is set, and `optimum-rbln` compiles in the loaded dtype — the explicit argument is required for the pipelines to compile and run in 16-bit.
+  * Diffusers: SDXL ControlNet i2i prompt kept in sync with the input images.
+  * **Qwen3.5 27B / Qwen3.6 27B** moved to TP16 (`num_devices=16`; LM and `visual` split across devices).
+  * Serving: vLLM wheels index bumped to **0.24.0** (Triton `setup.sh`, RayServe `requirements.txt`).
+* **Fixes**
+  * `yolov5-face`: skip the Google Drive download when the weight file is already present.
+  * `yolov5` (torch.compile): bypass an untraceable version check in the dynamo path.
+  * `cosmos_transfer1`: pin `nltk==3.10.2` so the Cosmos Guardrail loads from the HF cache.
+
 ## July, 31st 2026 (v0.11.1)
 
 * Compatible versions:

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Compile a model, then serve it on a supported inference server.
 cd huggingface/transformers/text2text-generation/llama/llama3.1-8b
 python compile.py
 uv pip install \
-  --extra-index-url https://wheels.vllm.ai/0.22.0/cpu \
+  --extra-index-url https://wheels.vllm.ai/0.24.0/cpu \
   --torch-backend cpu \
   vllm-rbln
 ```

--- a/huggingface/diffusers/image-to-image/kandinsky2_2_i2i/compile.py
+++ b/huggingface/diffusers/image-to-image/kandinsky2_2_i2i/compile.py
@@ -1,5 +1,6 @@
 import os
 
+import torch
 from optimum.rbln import RBLNKandinskyV22Img2ImgPipeline, RBLNKandinskyV22PriorPipeline
 
 
@@ -10,11 +11,13 @@ def main():
     # Compile and export
     prior_pipe = RBLNKandinskyV22PriorPipeline.from_pretrained(
         prior_model_id,
+        torch_dtype=torch.float16,
         export=True,  # export a PyTorch model to RBLN model with optimum
     )
 
     decoder_pipe = RBLNKandinskyV22Img2ImgPipeline.from_pretrained(
         decoder_model_id,
+        torch_dtype=torch.float16,
         export=True,
         rbln_config={"img_height": 768, "img_width": 768, "unet": {"batch_size": 2}},
     )

--- a/huggingface/diffusers/image-to-image/kandinsky2_2_i2i_combined/compile.py
+++ b/huggingface/diffusers/image-to-image/kandinsky2_2_i2i_combined/compile.py
@@ -1,5 +1,6 @@
 import os
 
+import torch
 from optimum.rbln import RBLNAutoPipelineForImage2Image
 
 
@@ -9,6 +10,7 @@ def main():
     # Compile and export
     pipe = RBLNAutoPipelineForImage2Image.from_pretrained(
         model_id,
+        torch_dtype=torch.float16,
         export=True,  # export a PyTorch model to RBLN model with optimum
         rbln_config={"img_height": 768, "img_width": 768, "unet": {"batch_size": 2}},
     )

--- a/huggingface/diffusers/image-to-image/stable_diffusion_3_i2i/compile.py
+++ b/huggingface/diffusers/image-to-image/stable_diffusion_3_i2i/compile.py
@@ -1,5 +1,6 @@
 import os
 
+import torch
 from optimum.rbln import RBLNAutoPipelineForImage2Image
 
 
@@ -9,6 +10,7 @@ def main():
     # Compile and export
     pipe = RBLNAutoPipelineForImage2Image.from_pretrained(
         model_id,
+        torch_dtype=torch.float16,
         export=True,  # export a PyTorch model to RBLN model with optimum
         rbln_img_height=1024,
         rbln_img_width=1024,

--- a/huggingface/diffusers/image-to-image/stable_diffusion_i2i/sd-v1.5-controlnet/compile.py
+++ b/huggingface/diffusers/image-to-image/stable_diffusion_i2i/sd-v1.5-controlnet/compile.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 
+import torch
 from diffusers import ControlNetModel
 from optimum.rbln import RBLNAutoModelForDepthEstimation, RBLNAutoPipelineForImage2Image
 
@@ -26,11 +27,14 @@ def main():
     args = parsing_argument()
     model_id = "benjamin-paine/stable-diffusion-v1-5"
 
-    controlnet = ControlNetModel.from_pretrained("lllyasviel/control_v11f1p_sd15_depth")
+    controlnet = ControlNetModel.from_pretrained(
+        "lllyasviel/control_v11f1p_sd15_depth", torch_dtype=torch.float16
+    )
 
     # Compile and export
     pipe = RBLNAutoPipelineForImage2Image.from_pretrained(
         model_id,
+        torch_dtype=torch.float16,
         export=True,  # export a PyTorch model to RBLN model with optimum
         rbln_img_width=args.img_width,
         rbln_img_height=args.img_height,

--- a/huggingface/diffusers/image-to-image/stable_diffusion_i2i/sd-v1.5/compile.py
+++ b/huggingface/diffusers/image-to-image/stable_diffusion_i2i/sd-v1.5/compile.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 
+import torch
 from optimum.rbln import RBLNAutoPipelineForImage2Image
 
 
@@ -28,6 +29,8 @@ def main():
     # Compile and export
     pipe = RBLNAutoPipelineForImage2Image.from_pretrained(
         model_id,
+        torch_dtype=torch.float16,
+        variant="fp16",
         export=True,  # export a PyTorch model to RBLN model with optimum
         rbln_img_width=args.img_width,
         rbln_img_height=args.img_height,

--- a/huggingface/diffusers/image-to-image/stable_diffusion_xl_i2i/sdxl-base-1.0-controlnet/compile.py
+++ b/huggingface/diffusers/image-to-image/stable_diffusion_xl_i2i/sdxl-base-1.0-controlnet/compile.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 
+import torch
 from diffusers import AutoencoderKL, ControlNetModel
 from optimum.rbln import RBLNAutoModelForDepthEstimation, RBLNAutoPipelineForImage2Image
 
@@ -27,13 +28,16 @@ def main():
     model_id = "stabilityai/stable-diffusion-xl-base-1.0"
 
     controlnet = ControlNetModel.from_pretrained(
-        "diffusers/controlnet-depth-sdxl-1.0-small"
+        "diffusers/controlnet-depth-sdxl-1.0-small", torch_dtype=torch.float16
     )
-    vae = AutoencoderKL.from_pretrained("madebyollin/sdxl-vae-fp16-fix")
+    vae = AutoencoderKL.from_pretrained(
+        "madebyollin/sdxl-vae-fp16-fix", torch_dtype=torch.float16
+    )
 
     # Compile and export
     pipe = RBLNAutoPipelineForImage2Image.from_pretrained(
         model_id,
+        torch_dtype=torch.float16,
         export=True,  # export a PyTorch model to RBLN model with optimum
         controlnet=controlnet,
         vae=vae,

--- a/huggingface/diffusers/image-to-image/stable_diffusion_xl_i2i/sdxl-base-1.0/compile.py
+++ b/huggingface/diffusers/image-to-image/stable_diffusion_xl_i2i/sdxl-base-1.0/compile.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 
+import torch
 from optimum.rbln import RBLNAutoPipelineForImage2Image
 
 
@@ -35,6 +36,8 @@ def main():
     # Compile and export
     pipe = RBLNAutoPipelineForImage2Image.from_pretrained(
         model_id,
+        torch_dtype=torch.float16,
+        variant="fp16",
         export=True,  # export a PyTorch model to RBLN model with optimum
         rbln_guidance_scale=guidance_scale,
         rbln_img_width=args.img_width,

--- a/huggingface/diffusers/image-to-image/stable_diffusion_xl_i2i/sdxl-turbo/compile.py
+++ b/huggingface/diffusers/image-to-image/stable_diffusion_xl_i2i/sdxl-turbo/compile.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 
+import torch
 from optimum.rbln import RBLNAutoPipelineForImage2Image
 
 
@@ -28,6 +29,7 @@ def main():
     # Compile and export
     pipe = RBLNAutoPipelineForImage2Image.from_pretrained(
         model_id,
+        torch_dtype=torch.float16,
         export=True,  # export a PyTorch model to RBLN model with optimum
         rbln_guidance_scale=0.0,
         rbln_img_width=args.img_width,

--- a/huggingface/diffusers/image-to-video/stable_video_diffusion/compile.py
+++ b/huggingface/diffusers/image-to-video/stable_video_diffusion/compile.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 
+import torch
 from optimum.rbln import RBLNStableVideoDiffusionPipeline
 
 DEFAULT_FRAMES_AND_DECODE_CHUNK_SIZE = {
@@ -30,6 +31,8 @@ def main():
     # Compile and export
     pipe = RBLNStableVideoDiffusionPipeline.from_pretrained(
         model_id,
+        torch_dtype=torch.float16,
+        variant="fp16",
         export=True,  # export a PyTorch model to RBLN model with optimum
         rbln_height=576,
         rbln_width=1024,

--- a/huggingface/diffusers/inpainting/kandinsky2_2_inpaint/compile.py
+++ b/huggingface/diffusers/inpainting/kandinsky2_2_inpaint/compile.py
@@ -1,5 +1,6 @@
 import os
 
+import torch
 from optimum.rbln import RBLNKandinskyV22InpaintPipeline, RBLNKandinskyV22PriorPipeline
 
 
@@ -10,11 +11,13 @@ def main():
     # Compile and export
     prior_pipe = RBLNKandinskyV22PriorPipeline.from_pretrained(
         prior_model_id,
+        torch_dtype=torch.float16,
         export=True,  # export a PyTorch model to RBLN model with optimum
     )
 
     decoder_pipe = RBLNKandinskyV22InpaintPipeline.from_pretrained(
         decoder_model_id,
+        torch_dtype=torch.float16,
         export=True,
         rbln_config={"img_height": 768, "img_width": 768, "unet": {"batch_size": 2}},
     )

--- a/huggingface/diffusers/inpainting/kandinsky2_2_inpaint_combined/compile.py
+++ b/huggingface/diffusers/inpainting/kandinsky2_2_inpaint_combined/compile.py
@@ -1,5 +1,6 @@
 import os
 
+import torch
 from optimum.rbln import RBLNAutoPipelineForInpainting
 
 
@@ -9,6 +10,7 @@ def main():
     # Compile and export
     pipe = RBLNAutoPipelineForInpainting.from_pretrained(
         model_id,
+        torch_dtype=torch.float16,
         export=True,  # export a PyTorch model to RBLN model with optimum
         rbln_config={
             "img_height": 768,

--- a/huggingface/diffusers/inpainting/stable_diffusion_3_inpaint/compile.py
+++ b/huggingface/diffusers/inpainting/stable_diffusion_3_inpaint/compile.py
@@ -1,5 +1,6 @@
 import os
 
+import torch
 from optimum.rbln import RBLNAutoPipelineForInpainting
 
 
@@ -9,6 +10,7 @@ def main():
     # Compile and export
     pipe = RBLNAutoPipelineForInpainting.from_pretrained(
         model_id,
+        torch_dtype=torch.float16,
         export=True,  # export a PyTorch model to RBLN model with optimum
         rbln_img_height=1024,
         rbln_img_width=1024,

--- a/huggingface/diffusers/inpainting/stable_diffusion_3_inpaint/inference.py
+++ b/huggingface/diffusers/inpainting/stable_diffusion_3_inpaint/inference.py
@@ -11,7 +11,7 @@ def parsing_argument():
     parser.add_argument(
         "--prompt",
         type=str,
-        default="cat wizard, gandalf, lord of the rings, detailed, fantasy, cute, adorable, Pixar, Disney, 8k",  # noqa: E501
+        default="Face of a yellow cat, high resolution, sitting on a park bench",  # noqa: E501
         help="(str) type, prompt for generate image",
     )
     return parser.parse_args()

--- a/huggingface/diffusers/inpainting/stable_diffusion_inpaint/compile.py
+++ b/huggingface/diffusers/inpainting/stable_diffusion_inpaint/compile.py
@@ -1,5 +1,6 @@
 import os
 
+import torch
 from optimum.rbln import RBLNAutoPipelineForInpainting
 
 
@@ -9,6 +10,7 @@ def main():
     # Compile and export
     pipe = RBLNAutoPipelineForInpainting.from_pretrained(
         model_id,
+        torch_dtype=torch.float16,
         export=True,  # export a PyTorch model to RBLN model with optimum
         rbln_guidance_scale=7.5,
     )

--- a/huggingface/diffusers/inpainting/stable_diffusion_xl_inpaint/compile.py
+++ b/huggingface/diffusers/inpainting/stable_diffusion_xl_inpaint/compile.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 
+import torch
 from optimum.rbln import RBLNAutoPipelineForInpainting
 
 
@@ -23,6 +24,7 @@ def main():
     # Compile and export
     pipe = RBLNAutoPipelineForInpainting.from_pretrained(
         model_id,
+        torch_dtype=torch.float16,
         export=True,  # export a PyTorch model to RBLN model with optimum
         rbln_guidance_scale=guidance_scale,
     )

--- a/huggingface/diffusers/text-to-image/kandinsky2_2_t2i/compile.py
+++ b/huggingface/diffusers/text-to-image/kandinsky2_2_t2i/compile.py
@@ -1,5 +1,6 @@
 import os
 
+import torch
 from optimum.rbln import RBLNKandinskyV22Pipeline, RBLNKandinskyV22PriorPipeline
 
 
@@ -10,11 +11,13 @@ def main():
     # Compile and export
     prior_pipe = RBLNKandinskyV22PriorPipeline.from_pretrained(
         prior_model_id,
+        torch_dtype=torch.float16,
         export=True,  # export a PyTorch model to RBLN model with optimum
     )
 
     decoder_pipe = RBLNKandinskyV22Pipeline.from_pretrained(
         decoder_model_id,
+        torch_dtype=torch.float16,
         export=True,
         rbln_config={
             "img_height": 768,

--- a/huggingface/diffusers/text-to-image/kandinsky2_2_t2i_combined/compile.py
+++ b/huggingface/diffusers/text-to-image/kandinsky2_2_t2i_combined/compile.py
@@ -1,5 +1,6 @@
 import os
 
+import torch
 from optimum.rbln import RBLNAutoPipelineForText2Image
 
 
@@ -9,6 +10,7 @@ def main():
     # Compile and export
     pipe = RBLNAutoPipelineForText2Image.from_pretrained(
         model_id,
+        torch_dtype=torch.float16,
         rbln_config={
             "img_height": 768,
             "img_width": 768,

--- a/huggingface/diffusers/text-to-image/stable_diffusion_3_t2i/compile.py
+++ b/huggingface/diffusers/text-to-image/stable_diffusion_3_t2i/compile.py
@@ -1,5 +1,6 @@
 import os
 
+import torch
 from optimum.rbln import RBLNAutoPipelineForText2Image
 
 
@@ -9,6 +10,7 @@ def main():
     # Compile and export
     pipe = RBLNAutoPipelineForText2Image.from_pretrained(
         model_id,
+        torch_dtype=torch.float16,
         export=True,  # export a PyTorch model to RBLN model with optimum
         rbln_img_height=1024,
         rbln_img_width=1024,

--- a/huggingface/diffusers/text-to-image/stable_diffusion_t2i/sd-v1.5-controlnet/compile.py
+++ b/huggingface/diffusers/text-to-image/stable_diffusion_t2i/sd-v1.5-controlnet/compile.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 
+import torch
 from diffusers import ControlNetModel
 from optimum.rbln import RBLNAutoPipelineForText2Image
 
@@ -26,11 +27,14 @@ def main():
     args = parsing_argument()
     model_id = "benjamin-paine/stable-diffusion-v1-5"
 
-    controlnet = ControlNetModel.from_pretrained("lllyasviel/sd-controlnet-canny")
+    controlnet = ControlNetModel.from_pretrained(
+        "lllyasviel/sd-controlnet-canny", torch_dtype=torch.float16
+    )
 
     # Compile and export
     pipe = RBLNAutoPipelineForText2Image.from_pretrained(
         model_id,
+        torch_dtype=torch.float16,
         export=True,  # export a PyTorch model to RBLN model with optimum
         controlnet=controlnet,
         rbln_config={

--- a/huggingface/diffusers/text-to-image/stable_diffusion_t2i/sd-v1.5-lcm-lora/compile.py
+++ b/huggingface/diffusers/text-to-image/stable_diffusion_t2i/sd-v1.5-lcm-lora/compile.py
@@ -1,5 +1,6 @@
 import os
 
+import torch
 from optimum.rbln import RBLNAutoPipelineForText2Image
 
 
@@ -14,6 +15,7 @@ def main():
     # Compile and export
     pipe = RBLNAutoPipelineForText2Image.from_pretrained(
         model_id,
+        torch_dtype=torch.float16,
         # Enable model export/compilation for NPU
         export=True,
         # LoRA configurations must be specified during model loading for RBLN compilation

--- a/huggingface/diffusers/text-to-image/stable_diffusion_t2i/sd-v1.5-multicontrolnet/compile.py
+++ b/huggingface/diffusers/text-to-image/stable_diffusion_t2i/sd-v1.5-multicontrolnet/compile.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 
+import torch
 from diffusers import ControlNetModel, UniPCMultistepScheduler
 from optimum.rbln import RBLNAutoPipelineForText2Image
 
@@ -32,12 +33,13 @@ def main():
 
     controlnets = []
     for cmi in controlnet_model_ids:
-        controlnet = ControlNetModel.from_pretrained(cmi)
+        controlnet = ControlNetModel.from_pretrained(cmi, torch_dtype=torch.float16)
         controlnets.append(controlnet)
 
     # Compile and export
     pipe = RBLNAutoPipelineForText2Image.from_pretrained(
         model_id,
+        torch_dtype=torch.float16,
         export=True,  # export a PyTorch model to RBLN model with optimum
         controlnet=controlnets,
         rbln_config={

--- a/huggingface/diffusers/text-to-image/stable_diffusion_t2i/sd-v1.5-multicontrolnet/inference.py
+++ b/huggingface/diffusers/text-to-image/stable_diffusion_t2i/sd-v1.5-multicontrolnet/inference.py
@@ -74,7 +74,7 @@ def main():
         prompt,
         images,
         negative_prompt=negative_prompt,
-        num_inference_steps=20,
+        num_inference_steps=25,
         controlnet_conditioning_scale=[1.0, 0.8],
     ).images[0]
 

--- a/huggingface/diffusers/text-to-image/stable_diffusion_t2i/sd-v1.5/compile.py
+++ b/huggingface/diffusers/text-to-image/stable_diffusion_t2i/sd-v1.5/compile.py
@@ -1,5 +1,6 @@
 import os
 
+import torch
 from optimum.rbln import RBLNAutoPipelineForText2Image
 
 
@@ -9,6 +10,7 @@ def main():
     # Compile and export
     pipe = RBLNAutoPipelineForText2Image.from_pretrained(
         model_id,
+        torch_dtype=torch.float16,
         export=True,  # export a PyTorch model to RBLN model with optimum
         rbln_config={"unet": {"batch_size": 2}},
     )

--- a/huggingface/diffusers/text-to-image/stable_diffusion_xl_t2i/sdxl-base-1.0-controlnet/compile.py
+++ b/huggingface/diffusers/text-to-image/stable_diffusion_xl_t2i/sdxl-base-1.0-controlnet/compile.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 
+import torch
 from diffusers import AutoencoderKL, ControlNetModel
 from optimum.rbln import RBLNAutoPipelineForText2Image
 
@@ -26,12 +27,17 @@ def main():
     args = parsing_argument()
     model_id = "stabilityai/stable-diffusion-xl-base-1.0"
 
-    controlnet = ControlNetModel.from_pretrained("diffusers/controlnet-canny-sdxl-1.0")
-    vae = AutoencoderKL.from_pretrained("madebyollin/sdxl-vae-fp16-fix")
+    controlnet = ControlNetModel.from_pretrained(
+        "diffusers/controlnet-canny-sdxl-1.0", torch_dtype=torch.float16
+    )
+    vae = AutoencoderKL.from_pretrained(
+        "madebyollin/sdxl-vae-fp16-fix", torch_dtype=torch.float16
+    )
 
     # Compile and export
     pipe = RBLNAutoPipelineForText2Image.from_pretrained(
         model_id,
+        torch_dtype=torch.float16,
         export=True,  # export a PyTorch model to RBLN model with optimum
         controlnet=controlnet,
         vae=vae,

--- a/huggingface/diffusers/text-to-image/stable_diffusion_xl_t2i/sdxl-base-1.0-controlnet/inference.py
+++ b/huggingface/diffusers/text-to-image/stable_diffusion_xl_t2i/sdxl-base-1.0-controlnet/inference.py
@@ -18,6 +18,12 @@ def parsing_argument():
         help="(str) type, prompt for generate image",
     )
     parser.add_argument(
+        "--negative_prompt",
+        type=str,
+        default="low quality, bad quality, sketches",
+        help="(str) type, negative prompt for generate image",
+    )
+    parser.add_argument(
         "--controlnet_conditioning_scale",
         type=float,
         default=0.5,
@@ -30,6 +36,7 @@ def main():
     args = parsing_argument()
     model_id = "stabilityai/stable-diffusion-xl-base-1.0"
     prompt = args.prompt
+    negative_prompt = args.negative_prompt
     controlnet_conditioning_scale = args.controlnet_conditioning_scale
 
     image = load_image(
@@ -52,6 +59,7 @@ def main():
     # Generate image
     image = pipe(
         prompt,
+        negative_prompt=negative_prompt,
         controlnet_conditioning_scale=controlnet_conditioning_scale,
         image=canny_image,
     ).images[0]

--- a/huggingface/diffusers/text-to-image/stable_diffusion_xl_t2i/sdxl-base-1.0-pixel-lora/compile.py
+++ b/huggingface/diffusers/text-to-image/stable_diffusion_xl_t2i/sdxl-base-1.0-pixel-lora/compile.py
@@ -1,5 +1,6 @@
 import os
 
+import torch
 from optimum.rbln import RBLNAutoPipelineForText2Image
 
 
@@ -19,6 +20,7 @@ def main():
     # fused with the weights during compilation for NPU inference
     pipe = RBLNAutoPipelineForText2Image.from_pretrained(
         model_id,
+        torch_dtype=torch.float16,
         # Enable model export/compilation for NPU
         export=True,
         # LoRA configurations must be specified during model loading for RBLN compilation

--- a/huggingface/diffusers/text-to-image/stable_diffusion_xl_t2i/sdxl-base-1.0/compile.py
+++ b/huggingface/diffusers/text-to-image/stable_diffusion_xl_t2i/sdxl-base-1.0/compile.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 
+import torch
 from optimum.rbln import RBLNAutoPipelineForText2Image
 
 
@@ -23,6 +24,8 @@ def main():
     # Compile and export
     pipe = RBLNAutoPipelineForText2Image.from_pretrained(
         model_id,
+        torch_dtype=torch.float16,
+        variant="fp16",
         export=True,  # export a PyTorch model to RBLN model with optimum
         rbln_guidance_scale=guidance_scale,
     )

--- a/huggingface/diffusers/text-to-image/stable_diffusion_xl_t2i/sdxl-turbo/compile.py
+++ b/huggingface/diffusers/text-to-image/stable_diffusion_xl_t2i/sdxl-turbo/compile.py
@@ -1,5 +1,6 @@
 import os
 
+import torch
 from optimum.rbln import RBLNAutoPipelineForText2Image
 
 
@@ -10,6 +11,7 @@ def main():
     # As SDXL-turbo does not use guidance_scale, we disable them with rbln_guidance_scale=0.0
     pipe = RBLNAutoPipelineForText2Image.from_pretrained(
         model_id,
+        torch_dtype=torch.float16,
         export=True,  # export a PyTorch model to RBLN model with optimum
         rbln_guidance_scale=0.0,
     )

--- a/huggingface/diffusers/text-to-video/cosmos-predict1-14b/compile.py
+++ b/huggingface/diffusers/text-to-video/cosmos-predict1-14b/compile.py
@@ -1,5 +1,6 @@
 import os
 
+import torch
 from cosmos_upsampler import (
     RBLNMistralNeMoForTextUpsampler,
     RBLNMistralNeMoForTextUpsamplerConfig,
@@ -40,6 +41,7 @@ def main():
 
     pipe = RBLNCosmosTextToWorldPipeline.from_pretrained(
         model_id,
+        torch_dtype=torch.bfloat16,
         export=True,  # export PyTorch models to RBLN models with optimum
         rbln_config={
             "height": height,

--- a/huggingface/diffusers/text-to-video/cosmos-predict1-7b/compile.py
+++ b/huggingface/diffusers/text-to-video/cosmos-predict1-7b/compile.py
@@ -1,5 +1,6 @@
 import os
 
+import torch
 from cosmos_upsampler import (
     RBLNMistralNeMoForTextUpsampler,
     RBLNMistralNeMoForTextUpsamplerConfig,
@@ -40,6 +41,7 @@ def main():
 
     pipe = RBLNCosmosTextToWorldPipeline.from_pretrained(
         model_id,
+        torch_dtype=torch.bfloat16,
         export=True,  # export PyTorch models to RBLN models with optimum
         rbln_config={
             "height": height,

--- a/huggingface/diffusers/text-to-video/cosmos-predict1-7b/requirements.txt
+++ b/huggingface/diffusers/text-to-video/cosmos-predict1-7b/requirements.txt
@@ -1,3 +1,4 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 optimum-rbln
 cosmos-guardrail==0.3.1
+nltk==3.10.2

--- a/huggingface/diffusers/video-to-video/cosmos-predict1-14b/compile.py
+++ b/huggingface/diffusers/video-to-video/cosmos-predict1-14b/compile.py
@@ -1,5 +1,6 @@
 import os
 
+import torch
 from optimum.rbln import (
     RBLNAutoModelForImageTextToText,
     RBLNCosmosVideoToWorldPipeline,
@@ -42,6 +43,7 @@ def main():
     # Compile and export
     pipe = RBLNCosmosVideoToWorldPipeline.from_pretrained(
         model_id,
+        torch_dtype=torch.bfloat16,
         export=True,  # export PyTorch models to RBLN models with optimum
         rbln_config={
             "height": height,

--- a/huggingface/diffusers/video-to-video/cosmos-predict1-7b/compile.py
+++ b/huggingface/diffusers/video-to-video/cosmos-predict1-7b/compile.py
@@ -1,5 +1,6 @@
 import os
 
+import torch
 from optimum.rbln import (
     RBLNAutoModelForImageTextToText,
     RBLNCosmosVideoToWorldPipeline,
@@ -42,6 +43,7 @@ def main():
     # Compile and export
     pipe = RBLNCosmosVideoToWorldPipeline.from_pretrained(
         model_id,
+        torch_dtype=torch.bfloat16,
         export=True,  # export PyTorch models to RBLN models with optimum
         rbln_config={
             "height": height,

--- a/huggingface/third-party-models/video-to-video/cosmos_transfer1/requirements.txt
+++ b/huggingface/third-party-models/video-to-video/cosmos_transfer1/requirements.txt
@@ -13,7 +13,7 @@ loguru>=0.7.3
 matplotlib>=3.8.0
 mistral_common>=1.8.5
 natsort==8.4.0
-nltk==3.9.1
+nltk==3.10.2
 onnxruntime==1.22.1
 opencv-python-headless>=4.11.0
 optimum-rbln

--- a/huggingface/transformers/fill-mask/modernbert/compile.py
+++ b/huggingface/transformers/fill-mask/modernbert/compile.py
@@ -1,0 +1,37 @@
+import argparse
+import os
+
+from optimum.rbln import RBLNAutoModelForMaskedLM
+
+
+def parsing_argument():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--model_name",
+        type=str,
+        choices=["base", "large"],
+        default="base",
+        help="(str) type, Size of ModernBERT. [base or large]",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parsing_argument()
+    model_id = "answerdotai/ModernBERT-" + args.model_name
+
+    # Compile and export
+    model = RBLNAutoModelForMaskedLM.from_pretrained(
+        model_id=model_id,
+        export=True,  # export a PyTorch model to RBLN model with optimum
+        rbln_batch_size=1,
+        rbln_max_seq_len=512,
+    )
+
+    # Save compiled results to disk
+    model.save_pretrained(os.path.basename(model_id))
+
+
+if __name__ == "__main__":
+    main()

--- a/huggingface/transformers/fill-mask/modernbert/inference.py
+++ b/huggingface/transformers/fill-mask/modernbert/inference.py
@@ -1,0 +1,71 @@
+import argparse
+import os
+
+from optimum.rbln import RBLNAutoModelForMaskedLM
+from transformers import AutoTokenizer
+
+
+def parsing_argument():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--model_name",
+        type=str,
+        choices=["base", "large"],
+        default="base",
+        help="(str) type, Size of ModernBERT. [base or large]",
+    )
+    parser.add_argument(
+        "--text",
+        type=str,
+        default="Plants create [MASK] through a process known as photosynthesis.",
+        help="(str) type, text for score",
+    )
+    parser.add_argument(
+        "--top_k",
+        type=int,
+        default=5,
+        help="(int) type, number of top predictions",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parsing_argument()
+    model_id = "answerdotai/ModernBERT-" + args.model_name
+
+    # Load compiled model and tokenizer
+    model = RBLNAutoModelForMaskedLM.from_pretrained(
+        model_id=os.path.basename(model_id),
+        export=False,
+    )
+
+    tokenizer = AutoTokenizer.from_pretrained(model_id)
+
+    # ModernBERT takes only input_ids and attention_mask (no token_type_ids)
+    inputs = tokenizer(
+        args.text,
+        max_length=512,
+        padding="max_length",
+        truncation=True,
+        return_tensors="pt",
+    )
+
+    output = model(inputs.input_ids, inputs.attention_mask)[0]
+
+    # Predict the masked words in the sentence
+    masked_index = (inputs.input_ids.squeeze() == tokenizer.mask_token_id).nonzero()
+
+    print("--- text ---")
+    print(args.text)
+    print("--- predictions ---")
+    for mask_index in masked_index:
+        mask_logits = output.squeeze()[mask_index.item()]
+        probs = mask_logits.softmax(dim=-1)
+        values, predictions = probs.topk(args.top_k)
+        for value, prediction in zip(values.tolist(), predictions.tolist()):
+            print(f"{tokenizer.decode([prediction]).strip()}: {value:.5f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/huggingface/transformers/fill-mask/modernbert/requirements.txt
+++ b/huggingface/transformers/fill-mask/modernbert/requirements.txt
@@ -1,4 +1,2 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 optimum-rbln
-cosmos-guardrail==0.3.1
-nltk==3.10.2

--- a/huggingface/transformers/image-text-to-text/qwen3.6/qwen3.6-27b/compile.py
+++ b/huggingface/transformers/image-text-to-text/qwen3.6/qwen3.6-27b/compile.py
@@ -20,10 +20,10 @@ def main():
                 # per image or video frame, so set `max_seq_len` to match the maximum expected
                 # resolution to reduce computation.
                 "max_seq_len": 16384,
-                "tensor_parallel_size": 8,
+                "tensor_parallel_size": 16,
                 "create_runtimes": False,
             },
-            "tensor_parallel_size": 8,
+            "tensor_parallel_size": 16,
             "kvcache_partition_len": 16_384,
             # Max position embedding for the language model, must be a multiple of kvcache_partition_len.
             "max_seq_len": 262_144,

--- a/huggingface/transformers/image-text-to-text/qwen3.6/qwen3.6-27b/inference.py
+++ b/huggingface/transformers/image-text-to-text/qwen3.6/qwen3.6-27b/inference.py
@@ -29,9 +29,9 @@ def main():
         rbln_config={
             "visual": {
                 # The `device` parameter specifies which device should be used for each submodule during runtime.
-                "device": [8, 9, 10, 11, 12, 13, 14, 15],
+                "device": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
             },
-            "device": [0, 1, 2, 3, 4, 5, 6, 7],
+            "device": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
         },
     )
 

--- a/huggingface/transformers/image-text-to-text/qwen3.8/qwen3.8-27b/compile.py
+++ b/huggingface/transformers/image-text-to-text/qwen3.8/qwen3.8-27b/compile.py
@@ -4,13 +4,13 @@ from optimum.rbln import RBLNAutoModelForImageTextToText
 
 
 def main():
-    model_id = "Qwen/Qwen3.5-27B"
+    model_id = "Qwen/Qwen3.8-27B"
     model = RBLNAutoModelForImageTextToText.from_pretrained(
         model_id,
         export=True,
         rbln_config={
             # The `device` parameter specifies the device allocation for each submodule during runtime.
-            # As Qwen3.5 consists of multiple submodules, loading them all onto a single device may exceed its memory capacity, especially as the batch size increases.
+            # As Qwen3-VL consists of multiple submodules, loading them all onto a single device may exceed its memory capacity, especially as the batch size increases.
             # By distributing submodules across devices, memory usage can be optimized for efficient runtime performance.
             "visual": {
                 # Maximum sequence lengths for Vision Transformer attention. Can be an integer or list of integers,

--- a/huggingface/transformers/image-text-to-text/qwen3.8/qwen3.8-27b/inference.py
+++ b/huggingface/transformers/image-text-to-text/qwen3.8/qwen3.8-27b/inference.py
@@ -16,7 +16,7 @@ def load_image(url):
 
 
 def main():
-    model_id = "Qwen/Qwen3.5-27B"
+    model_id = "Qwen/Qwen3.8-27B"
     model_dir = os.path.basename(model_id)
 
     # Load compiled model

--- a/huggingface/transformers/image-text-to-text/qwen3.8/qwen3.8-27b/requirements.txt
+++ b/huggingface/transformers/image-text-to-text/qwen3.8/qwen3.8-27b/requirements.txt
@@ -1,4 +1,2 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 optimum-rbln
-cosmos-guardrail==0.3.1
-nltk==3.10.2

--- a/pytorch/vision/face_detection/yolov5-face/compile.py
+++ b/pytorch/vision/face_detection/yolov5-face/compile.py
@@ -34,8 +34,10 @@ def main():
     args = parsing_argument()
     model_name = args.model_name
 
-    # Get official pretrained weight from google drive
-    gdown.download(url=pt_file_urls[model_name], output=f"{model_name}.pt")
+    # Get official pretrained weight from google drive (skipped if already present,
+    # e.g. pre-downloaded to avoid the shared Google Drive download quota)
+    if not os.path.exists(f"{model_name}.pt"):
+        gdown.download(url=pt_file_urls[model_name], output=f"{model_name}.pt")
 
     # Override torch.load to set weights_only=False (default is True in PyTorch 2.6).
     with patch("torch.load", partial(torch.load, weights_only=False)):

--- a/pytorch_dynamo/vision/detection/yolov5/main.py
+++ b/pytorch_dynamo/vision/detection/yolov5/main.py
@@ -76,6 +76,16 @@ def main():
     model = torch.hub.load(yolov5_dir, model_name, source="local")
     model.eval()
 
+    # yolov5's smart_amp_autocast() calls packaging.version.parse to choose the
+    # autocast API. torch.compile/dynamo cannot trace packaging's Version.__init__
+    # (its `raise ... from None` trips a dynamo bug), so replace it with the modern
+    # torch.amp path directly (torch is pinned >= 2.4, so this matches upstream).
+    # See https://github.com/RBLN-SW/rbln-model-zoo/issues/91
+    def _smart_amp_autocast(enabled=True):
+        return torch.amp.autocast("cpu", enabled=enabled)
+
+    sys.modules[type(model).__module__].smart_amp_autocast = _smart_amp_autocast
+
     # Disable capturing warnings for torch.compile
     torch._dynamo.allow_in_graph(warnings.simplefilter)
 

--- a/serving/rayserve/llama3-8b/material/requirements.txt
+++ b/serving/rayserve/llama3-8b/material/requirements.txt
@@ -1,4 +1,4 @@
---extra-index-url https://wheels.vllm.ai/0.22.0/cpu
+--extra-index-url https://wheels.vllm.ai/0.24.0/cpu
 --extra-index-url https://download.pytorch.org/whl/cpu
 ray[serve]==2.51.1
 requests>=2.32.3

--- a/serving/rayserve/llama3.1-8b/material/requirements.txt
+++ b/serving/rayserve/llama3.1-8b/material/requirements.txt
@@ -1,4 +1,4 @@
---extra-index-url https://wheels.vllm.ai/0.22.0/cpu
+--extra-index-url https://wheels.vllm.ai/0.24.0/cpu
 --extra-index-url https://download.pytorch.org/whl/cpu
 ray[serve]==2.51.1
 requests>=2.32.3

--- a/serving/triton_inference_server/llama3-8b/setup.sh
+++ b/serving/triton_inference_server/llama3-8b/setup.sh
@@ -13,7 +13,7 @@ echo "=================================================================="
 DIR="vllm_backend"
 GIT_REPO="https://github.com/triton-inference-server/${DIR}.git"
 if [ ! -d ${DIR} ]; then
-  git clone ${GIT_REPO} -b r26.06
+  git clone ${GIT_REPO} -b r26.07
   if [ $? -ne 0 ]; then
     echo "Error while cloning git repository."
     popd

--- a/serving/triton_inference_server/llama3.1-8b/setup.sh
+++ b/serving/triton_inference_server/llama3.1-8b/setup.sh
@@ -13,7 +13,7 @@ echo "=================================================================="
 DIR="vllm_backend"
 GIT_REPO="https://github.com/triton-inference-server/${DIR}.git"
 if [ ! -d ${DIR} ]; then
-  git clone ${GIT_REPO} -b r26.06
+  git clone ${GIT_REPO} -b r26.07
   if [ $? -ne 0 ]; then
     echo "Error while cloning git repository."
     popd

--- a/serving/triton_inference_server/resnet50/setup.sh
+++ b/serving/triton_inference_server/resnet50/setup.sh
@@ -37,7 +37,7 @@ echo "=================================================================="
 BE_DIR="python_backend"
 GIT_REPO="https://github.com/triton-inference-server/${BE_DIR}.git"
 if [ ! -d ${BE_DIR} ]; then
-  git clone ${GIT_REPO} -b r25.08
+  git clone ${GIT_REPO} -b r26.07
   if [ $? -ne 0 ]; then
     echo "Error while cloning git repository."
     popd

--- a/serving/triton_inference_server/yolov8/setup.sh
+++ b/serving/triton_inference_server/yolov8/setup.sh
@@ -53,7 +53,7 @@ echo "=================================================================="
 BE_DIR="python_backend"
 GIT_REPO="https://github.com/triton-inference-server/${BE_DIR}.git"
 if [ ! -d ${BE_DIR} ]; then
-  git clone ${GIT_REPO} -b r25.08
+  git clone ${GIT_REPO} -b r26.07
   if [ $? -ne 0 ]; then
     echo "Error while cloning git repository."
     popd


### PR DESCRIPTION
# 🚀 Release Notes · August 28, 2026

| | |
| :-- | :-- |
| **✨ New models** | ![Qwen3.8](https://img.shields.io/badge/Qwen3.8-27B-00C853) ![ModernBERT](https://img.shields.io/badge/ModernBERT-fill--mask-00C853) |
| **📦 Package bumps** | ![vLLM](https://img.shields.io/badge/vLLM-0.24.0-7B1FA2) |

---

## ✨ Spotlight: Qwen3.8 27B and ModernBERT

This release adds **Qwen3.8 27B** — the next iteration of the natively multimodal Qwen3.x line — and **ModernBERT**, the zoo's first `fill-mask` example. Alongside them, the existing **Qwen3.5 27B / Qwen3.6 27B** examples move to **TP16**, splitting the language model and the visual encoder across 16 devices.

---

## 🆕 New models

| Task | Model | Path |
| --- | --- | --- |
| Image-Text-to-Text (VLM) | **Qwen3.8** (27B) | `huggingface/transformers/image-text-to-text/qwen3.8/qwen3.8-27b/` |
| Fill-Mask | **ModernBERT** | `huggingface/transformers/fill-mask/modernbert/` |

---

## 🔧 Improvements

| Area | Change |
| --- | --- |
| Diffusers (33 examples) | compile scripts now pass an explicit `torch_dtype=torch.float16` to `from_pretrained` (plus `variant="fp16"` where the checkpoint publishes fp16 shards). Diffusers loads weights as **fp32** unless `torch_dtype` is set, and the RBLN compiler compiles in the loaded dtype — the explicit argument is what makes these pipelines compile and run in true 16-bit |
| Diffusers (SDXL ControlNet i2i) | prompt kept in sync with the input images |
| Qwen3.5 27B · Qwen3.6 27B | moved to **TP16** (`num_devices=16`; LM and `visual` split across devices) |
| Serving | vLLM wheels index bumped to **0.24.0** (Triton `setup.sh`, RayServe `requirements.txt`) |

## 🐛 Fixes

| Example | Fix |
| --- | --- |
| `yolov5-face` | skip the Google Drive download when the weight file is already present |
| `yolov5` (torch.compile) | bypass an untraceable version check in the dynamo path |
| `cosmos_transfer1` | pin `nltk==3.10.2` so the Cosmos Guardrail loads from the HF cache |

## 🧹 Housekeeping

- `.gitignore` aligned with the development tree.